### PR TITLE
Switch off unneeded options in cmake

### DIFF
--- a/libaeron-sys/build.rs
+++ b/libaeron-sys/build.rs
@@ -57,6 +57,11 @@ pub fn main() {
     }
 
     let cmake_output = Config::new(&aeron_path)
+        .define("BUILD_AERON_DRIVER", "OFF")
+        .define("BUILD_AERON_ARCHIVE_API", "OFF")
+        .define("AERON_TESTS", "OFF")
+        .define("AERON_BUILD_SAMPLES", "OFF")
+        .define("AERON_BUILD_DOCUMENTATION", "OFF")
         .build_target(link_type.target_name())
         .build();
 

--- a/libaeron_driver-sys/build.rs
+++ b/libaeron_driver-sys/build.rs
@@ -57,6 +57,11 @@ pub fn main() {
     }
 
     let cmake_output = Config::new(&aeron_path)
+        .define("BUILD_AERON_DRIVER", "ON")
+        .define("BUILD_AERON_ARCHIVE_API", "OFF")
+        .define("AERON_TESTS", "OFF")
+        .define("AERON_BUILD_SAMPLES", "OFF")
+        .define("AERON_BUILD_DOCUMENTATION", "OFF")
         .build_target(link_type.target_name())
         .build();
 


### PR DESCRIPTION
With this change it doesn't fail if Java isn't installed, and it's quicker to build