### PR TITLE
Upgrade to Aeron 1.47.0 and add libaeron_archive_c_client-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: [default, static]
-        rust-version: ["stable", "stable 6 months ago"]
+        rust-version: ["stable"]
 
     env:
       feature-flags: ${{ matrix.features != 'default' && format('--features {0}', matrix.features) || '' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "libaeron_driver-sys/aeron"]
 	path = libaeron_driver-sys/aeron
 	url = https://github.com/real-logic/aeron.git
+[submodule "libaeron_archive_c_client-sys/aeron"]
+	path = libaeron_archive_c_client-sys/aeron
+	url = https://github.com/real-logic/aeron.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "libaeron-sys/aeron"]
 	path = libaeron-sys/aeron
-	url = https://github.com/real-logic/aeron.git
+	url = https://github.com/aeron-io/aeron.git
 [submodule "libaeron_driver-sys/aeron"]
 	path = libaeron_driver-sys/aeron
-	url = https://github.com/real-logic/aeron.git
+	url = https://github.com/aeron-io/aeron.git
 [submodule "libaeron_archive_c_client-sys/aeron"]
 	path = libaeron_archive_c_client-sys/aeron
-	url = https://github.com/real-logic/aeron.git
+	url = https://github.com/aeron-io/aeron.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "libaeron-sys",
     "libaeron_driver-sys",
+    "libaeron_archive_c_client-sys",
 ]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![libaeron-sys docs.rs](https://docs.rs/libaeron-sys/badge.svg)](https://docs.rs/libaeron-sys/)
 
-Rust bindings for the [Aeron](https://github.com/real-logic/aeron) messaging bus. Two crates are provided; one for the [C Client API](./libaeron-sys) and one for the [C Media Driver](./libaeron_driver-sys).
+Rust bindings for the [Aeron](https://github.com/aeron-io/aeron) messaging bus. Three crates are provided:
+* [C Client API](./libaeron-sys)
+* [C Archive Client API](./libaeron_archive_c_client-sys)
+* [C Media Driver](./libaeron_driver-sys)
 
 Please note that these crates do not provide an idiomatic Rust API for interacting with Aeron; [`aeron-rs`](https://crates.io/crates/aeron-rs) should be used instead. Rather, these libraries act as foundational components by which an Aeron client can be built.

--- a/libaeron-sys/Cargo.toml
+++ b/libaeron-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaeron-sys"
-version = "1.44.1"
+version = "1.47.0"
 authors = ["Bradlee Speice <bradlee@speice.io>"]
 repository = "https://github.com/bspeice/libaeron-sys"
 documentation = "https://docs.rs/libaeron-sys"

--- a/libaeron-sys/Cargo.toml
+++ b/libaeron-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaeron-sys"
-version = "1.47.0"
+version = "1.47.1"
 authors = ["Bradlee Speice <bradlee@speice.io>"]
 repository = "https://github.com/bspeice/libaeron-sys"
 documentation = "https://docs.rs/libaeron-sys"

--- a/libaeron-sys/README.md
+++ b/libaeron-sys/README.md
@@ -1,7 +1,7 @@
 # libaeron-sys
 
-[![github-ci](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml/badge.svg)](https://github.com/amoskvin/libaeron-sys/actions/workflows/ci.yml)
+[![github-ci](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml/badge.svg)](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml)
 [![libaeron-sys docs.rs](https://docs.rs/libaeron-sys/badge.svg)](https://docs.rs/libaeron-sys/)
 
-Rust bindings for the [Aeron](https://github.com/real-logic/aeron) C client [API](https://github.com/real-logic/aeron/tree/master/aeron-client). Note that this crate does not intend to provide an idiomatic client API, but instead acts as a foundation for other clients to build on top of.
+Rust bindings for the [Aeron](https://github.com/aeron-io/aeron) C client [API](https://github.com/aeron-io/aeron/tree/master/aeron-client). Note that this crate does not intend to provide an idiomatic client API, but instead acts as a foundation for other clients to build on top of.
 

--- a/libaeron_archive_c_client-sys/CMakeLists.txt
+++ b/libaeron_archive_c_client-sys/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
+
+# When Archive API is built, cmake calls out to Gradle to generate SBE codecs.
+# This greatly complicates the build, especially since Gradle proceeds with
+# downloading Java dependencies off the internet, which is not desirable.
+# Let's replace gradlew with "echo" to turn it into a no-op:
+set(GRADLE_WRAPPER "echo")
+
+# And instead, include pre-generated codecs
+include_directories("generated")
+
+# These aren't needed anymore
+set(Java_JAR_EXECUTABLE "DISABLED_FOR_LIBAERON_SYS")
+set(Java_JAVA_EXECUTABLE "DISABLED_FOR_LIBAERON_SYS")
+set(Java_JAVAC_EXECUTABLE "DISABLED_FOR_LIBAERON_SYS")
+set(Java_JAVAH_EXECUTABLE "DISABLED_FOR_LIBAERON_SYS")
+set(Java_JAVADOC_EXECUTABLE "DISABLED_FOR_LIBAERON_SYS")
+
+# Proceed with the build
+add_subdirectory("aeron")

--- a/libaeron_archive_c_client-sys/Cargo.toml
+++ b/libaeron_archive_c_client-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaeron_archive_c_client-sys"
-version = "1.47.0"
+version = "1.47.1"
 authors = ["Bradlee Speice <bradlee@speice.io>"]
 repository = "https://github.com/bspeice/libaeron-sys"
 documentation = "https://docs.rs/libaeron_archive_c_client-sys"
@@ -10,7 +10,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-libaeron-sys = { version = "=1.47.0", path = "../libaeron-sys" }
+libaeron-sys = { version = "=1.47.1", path = "../libaeron-sys" }
 
 [build-dependencies]
 bindgen = "0.68"

--- a/libaeron_archive_c_client-sys/Cargo.toml
+++ b/libaeron_archive_c_client-sys/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
-name = "libaeron_driver-sys"
+name = "libaeron_archive_c_client-sys"
 version = "1.47.0"
 authors = ["Bradlee Speice <bradlee@speice.io>"]
 repository = "https://github.com/bspeice/libaeron-sys"
-documentation = "https://docs.rs/libaeron_driver-sys"
-description = "Rust bindings for the Aeron Media Driver"
+documentation = "https://docs.rs/libaeron_archive_c_client-sys"
+description = "Rust bindings for the Aeron Archive Client"
 license = "Apache-2.0"
 edition = "2018"
 readme = "README.md"
 
 [dependencies]
+libaeron-sys = { version = "=1.47.0", path = "../libaeron-sys" }
 
 [build-dependencies]
 bindgen = "0.68"
@@ -17,4 +18,4 @@ cmake = "0.1"
 dunce = "1.0"
 
 [features]
-static = []
+static = ["libaeron-sys/static"]

--- a/libaeron_archive_c_client-sys/README.md
+++ b/libaeron_archive_c_client-sys/README.md
@@ -1,6 +1,6 @@
 # libaeron_archive_c_client-sys
 
 [![github-ci](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml/badge.svg)](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml)
-[![libaeron_archive_c_client-sys docs.rs](https://docs.rs/libaeron_archive_c_client-sys/badge.svg)](https://docs.rs/libaeron-sys/)
+[![libaeron_archive_c_client-sys docs.rs](https://docs.rs/libaeron_archive_c_client-sys/badge.svg)](https://docs.rs/libaeron_archive_c_client-sys/)
 
-Rust bindings for the [Aeron](https://github.com/real-logic/aeron) C client [API](https://github.com/real-logic/aeron/tree/master/aeron-archive). Note that this crate does not intend to provide an idiomatic client API, but instead acts as a foundation for other clients to build on top of.
+Rust bindings for the [Aeron](https://github.com/aeron-io/aeron) Archive C client [API](https://github.com/aeron-io/aeron/tree/master/aeron-archive). Note that this crate does not intend to provide an idiomatic client API, but instead acts as a foundation for other clients to build on top of.

--- a/libaeron_archive_c_client-sys/README.md
+++ b/libaeron_archive_c_client-sys/README.md
@@ -1,0 +1,6 @@
+# libaeron_archive_c_client-sys
+
+[![github-ci](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml/badge.svg)](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml)
+[![libaeron_archive_c_client-sys docs.rs](https://docs.rs/libaeron_archive_c_client-sys/badge.svg)](https://docs.rs/libaeron-sys/)
+
+Rust bindings for the [Aeron](https://github.com/real-logic/aeron) C client [API](https://github.com/real-logic/aeron/tree/master/aeron-archive). Note that this crate does not intend to provide an idiomatic client API, but instead acts as a foundation for other clients to build on top of.

--- a/libaeron_archive_c_client-sys/bindings.h
+++ b/libaeron_archive_c_client-sys/bindings.h
@@ -1,0 +1,2 @@
+#include <stddef.h>
+#include <client/aeron_archive.h>

--- a/libaeron_archive_c_client-sys/build.rs
+++ b/libaeron_archive_c_client-sys/build.rs
@@ -1,0 +1,118 @@
+use cmake::Config;
+use dunce::canonicalize;
+use std::env;
+use std::path::{Path, PathBuf};
+
+pub enum LinkType {
+    Dynamic,
+    Static,
+}
+
+impl LinkType {
+    fn detect() -> LinkType {
+        if cfg!(feature = "static") {
+            LinkType::Static
+        } else {
+            LinkType::Dynamic
+        }
+    }
+
+    fn link_lib(&self) -> &'static str {
+        match self {
+            LinkType::Dynamic => "dylib=",
+            LinkType::Static => "static=",
+        }
+    }
+
+    fn target_name(&self) -> &'static str {
+        match self {
+            LinkType::Dynamic => "aeron_archive_c_client",
+            LinkType::Static => "aeron_archive_c_client_static",
+        }
+    }
+}
+
+pub fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=bindings.h");
+
+    let base_path = canonicalize(Path::new(".")).unwrap();
+    let aeron_path = canonicalize(base_path.join("aeron")).unwrap();
+    let client_header_path = aeron_path.join("aeron-client/src/main/c");
+    let archive_header_path = aeron_path.join("aeron-archive/src/main/c");
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let link_type = LinkType::detect();
+    println!(
+        "cargo:rustc-link-lib={}{}",
+        link_type.link_lib(),
+        link_type.target_name()
+    );
+
+    if let LinkType::Static = link_type {
+        // On Windows, there are some extra libraries needed for static link
+        // that aren't included by Aeron.
+        if cfg!(target_os = "windows") {
+            println!("cargo:rustc-link-lib=shell32");
+            println!("cargo:rustc-link-lib=iphlpapi");
+        }
+    }
+
+    let cmake_output = Config::new(base_path)
+        .define("BUILD_AERON_DRIVER", "OFF")
+        .define("BUILD_AERON_ARCHIVE_API", "ON")
+        .define("AERON_TESTS", "OFF")
+        .define("AERON_BUILD_SAMPLES", "OFF")
+        .define("AERON_BUILD_DOCUMENTATION", "OFF")
+        .define("GRADLE_WRAPPER", "false")
+        .build_target(link_type.target_name())
+        .build();
+
+    // Trying to figure out the final path is a bit weird;
+    // For Linux/OSX, it's just build/lib
+    // For Windows, the .lib file is in build/lib/{profile}, but the DLL
+    // is shipped in build/binaries/{profile}
+    let base_lib_dir = cmake_output.join("build/aeron");
+    println!(
+        "cargo:rustc-link-search=native={}",
+        base_lib_dir.join("lib").display()
+    );
+    // Because the `cmake_output` path is different for debug/release, we're not worried
+    // about accidentally linking the Debug library when this is a release build or vice-versa
+    println!(
+        "cargo:rustc-link-search=native={}",
+        base_lib_dir.join("lib/Debug").display()
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        base_lib_dir.join("binaries/Debug").display()
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        base_lib_dir.join("lib/Release").display()
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        base_lib_dir.join("binaries/Release").display()
+    );
+
+    println!("cargo:include={}", archive_header_path.display());
+    let bindings = bindgen::Builder::default()
+        .clang_arg(format!("-I{}", archive_header_path.display()))
+        // We need to include some of the headers from `libaeron`, so update the include path here
+        .clang_arg(format!("-I{}", client_header_path.display()))
+        .header("bindings.h")
+        .blocklist_file(".*aeronc.h")
+        .allowlist_function("aeron_.*")
+        .allowlist_type("aeron_.*")
+        .allowlist_var("AERON_.*")
+        .allowlist_var("ARCHIVE_.*")
+        .constified_enum_module("aeron_.*_en")
+        .constified_enum_module("aeron_.*_enum")
+        .generate()
+        .expect("Unable to generate aeron bindings");
+
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/archiveIdRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/archiveIdRequest.h
@@ -1,0 +1,545 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_ARCHIVEIDREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_ARCHIVEIDREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_archiveIdRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_archiveIdRequest_meta_attribute
+{
+    aeron_archive_client_archiveIdRequest_meta_attribute_EPOCH,
+    aeron_archive_client_archiveIdRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_archiveIdRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_archiveIdRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_archiveIdRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_archiveIdRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_archiveIdRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_archiveIdRequest_sbe_position(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_archiveIdRequest_set_sbe_position(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_archiveIdRequest_sbe_position_ptr(
+    struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_reset(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_archiveIdRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_copy(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    const struct aeron_archive_client_archiveIdRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_archiveIdRequest_sbe_block_length(void)
+{
+    return (uint16_t)16;
+}
+
+#define AERON_ARCHIVE_CLIENT_ARCHIVE_ID_REQUEST_SBE_TEMPLATE_ID (uint16_t)68
+
+SBE_ONE_DEF uint16_t aeron_archive_client_archiveIdRequest_sbe_template_id(void)
+{
+    return (uint16_t)68;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_archiveIdRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_archiveIdRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_archiveIdRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_archiveIdRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_archiveIdRequest_offset(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_wrap_and_apply_header(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_archiveIdRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_archiveIdRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_archiveIdRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_archiveIdRequest_sbe_schema_version());
+
+    aeron_archive_client_archiveIdRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_archiveIdRequest_sbe_block_length(),
+        aeron_archive_client_archiveIdRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_wrap_for_encode(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_archiveIdRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_archiveIdRequest_sbe_block_length(),
+        aeron_archive_client_archiveIdRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_wrap_for_decode(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_archiveIdRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_sbe_rewind(
+    struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return aeron_archive_client_archiveIdRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_archiveIdRequest_encoded_length(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return aeron_archive_client_archiveIdRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_archiveIdRequest_buffer(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_archiveIdRequest_mut_buffer(
+    struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_archiveIdRequest_buffer_length(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_archiveIdRequest_acting_version(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_archiveIdRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_archiveIdRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_archiveIdRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_archiveIdRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_archiveIdRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_archiveIdRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_archiveIdRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_archiveIdRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_archiveIdRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_archiveIdRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_archiveIdRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_archiveIdRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_controlSessionId(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_set_controlSessionId(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_archiveIdRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_archiveIdRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_archiveIdRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_archiveIdRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_archiveIdRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_archiveIdRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_archiveIdRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_archiveIdRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_archiveIdRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_archiveIdRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_archiveIdRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_archiveIdRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_archiveIdRequest_correlationId(
+    const struct aeron_archive_client_archiveIdRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_archiveIdRequest *aeron_archive_client_archiveIdRequest_set_correlationId(
+    struct aeron_archive_client_archiveIdRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/attachSegmentsRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/attachSegmentsRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_ATTACHSEGMENTSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_ATTACHSEGMENTSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_attachSegmentsRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_attachSegmentsRequest_meta_attribute
+{
+    aeron_archive_client_attachSegmentsRequest_meta_attribute_EPOCH,
+    aeron_archive_client_attachSegmentsRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_attachSegmentsRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_attachSegmentsRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_attachSegmentsRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_attachSegmentsRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_attachSegmentsRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_sbe_position(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_attachSegmentsRequest_set_sbe_position(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_attachSegmentsRequest_sbe_position_ptr(
+    struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_reset(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_attachSegmentsRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_copy(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    const struct aeron_archive_client_attachSegmentsRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_attachSegmentsRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_ATTACH_SEGMENTS_REQUEST_SBE_TEMPLATE_ID (uint16_t)56
+
+SBE_ONE_DEF uint16_t aeron_archive_client_attachSegmentsRequest_sbe_template_id(void)
+{
+    return (uint16_t)56;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_attachSegmentsRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_attachSegmentsRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_attachSegmentsRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_attachSegmentsRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_offset(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_wrap_and_apply_header(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_attachSegmentsRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_attachSegmentsRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_attachSegmentsRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_attachSegmentsRequest_sbe_schema_version());
+
+    aeron_archive_client_attachSegmentsRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_attachSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_attachSegmentsRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_wrap_for_encode(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_attachSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_attachSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_attachSegmentsRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_wrap_for_decode(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_attachSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_sbe_rewind(
+    struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return aeron_archive_client_attachSegmentsRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_encoded_length(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return aeron_archive_client_attachSegmentsRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_attachSegmentsRequest_buffer(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_attachSegmentsRequest_mut_buffer(
+    struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_buffer_length(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_acting_version(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_attachSegmentsRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_attachSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_attachSegmentsRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_attachSegmentsRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_attachSegmentsRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_attachSegmentsRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_attachSegmentsRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_controlSessionId(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_set_controlSessionId(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_attachSegmentsRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_attachSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_attachSegmentsRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_attachSegmentsRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_attachSegmentsRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_attachSegmentsRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_attachSegmentsRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_correlationId(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_set_correlationId(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_attachSegmentsRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_attachSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_attachSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_attachSegmentsRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_attachSegmentsRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_attachSegmentsRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_attachSegmentsRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_attachSegmentsRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_attachSegmentsRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_attachSegmentsRequest_recordingId(
+    const struct aeron_archive_client_attachSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_attachSegmentsRequest *aeron_archive_client_attachSegmentsRequest_set_recordingId(
+    struct aeron_archive_client_attachSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/authConnectRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/authConnectRequest.h
@@ -1,0 +1,924 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_AUTHCONNECTREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_AUTHCONNECTREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_authConnectRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_authConnectRequest_meta_attribute
+{
+    aeron_archive_client_authConnectRequest_meta_attribute_EPOCH,
+    aeron_archive_client_authConnectRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_authConnectRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_authConnectRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_authConnectRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_authConnectRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_authConnectRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_sbe_position(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_authConnectRequest_set_sbe_position(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_authConnectRequest_sbe_position_ptr(
+    struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_reset(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_copy(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    const struct aeron_archive_client_authConnectRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_sbe_block_length(void)
+{
+    return (uint16_t)16;
+}
+
+#define AERON_ARCHIVE_CLIENT_AUTH_CONNECT_REQUEST_SBE_TEMPLATE_ID (uint16_t)58
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_sbe_template_id(void)
+{
+    return (uint16_t)58;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_authConnectRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_offset(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_wrap_and_apply_header(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_authConnectRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_authConnectRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_authConnectRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_authConnectRequest_sbe_schema_version());
+
+    aeron_archive_client_authConnectRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_authConnectRequest_sbe_block_length(),
+        aeron_archive_client_authConnectRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_wrap_for_encode(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_authConnectRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_authConnectRequest_sbe_block_length(),
+        aeron_archive_client_authConnectRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_wrap_for_decode(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_authConnectRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_sbe_rewind(
+    struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return aeron_archive_client_authConnectRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_encoded_length(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return aeron_archive_client_authConnectRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_buffer(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_authConnectRequest_mut_buffer(
+    struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_buffer_length(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_acting_version(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_authConnectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_authConnectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_correlationId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_authConnectRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_authConnectRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_authConnectRequest_correlationId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_authConnectRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_authConnectRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_authConnectRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_authConnectRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_authConnectRequest_correlationId(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_set_correlationId(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_responseStreamId_meta_attribute(
+    const enum aeron_archive_client_authConnectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_authConnectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_responseStreamId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_responseStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_authConnectRequest_responseStreamId_in_acting_version(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_authConnectRequest_responseStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_authConnectRequest_responseStreamId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_responseStreamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_responseStreamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_responseStreamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_authConnectRequest_responseStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_responseStreamId(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_set_responseStreamId(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_version_meta_attribute(
+    const enum aeron_archive_client_authConnectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_authConnectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_PRESENCE: return "optional";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_version_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_version_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_authConnectRequest_version_in_acting_version(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_authConnectRequest_version_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_authConnectRequest_version_encoding_offset(void)
+{
+    return 12;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_version_null_value(void)
+{
+    return INT32_C(0);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_version_min_value(void)
+{
+    return INT32_C(2);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_version_max_value(void)
+{
+    return INT32_C(16777215);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_authConnectRequest_version_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_authConnectRequest_version(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 12, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_set_version(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 12, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_responseChannel_meta_attribute(
+    const enum aeron_archive_client_authConnectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_authConnectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_responseChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_responseChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_authConnectRequest_responseChannel_in_acting_version(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_authConnectRequest_responseChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_responseChannel_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_responseChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_authConnectRequest_responseChannel_length(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_responseChannel(
+    struct aeron_archive_client_authConnectRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(
+        codec, aeron_archive_client_authConnectRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_get_responseChannel(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_authConnectRequest_sbe_position(codec);
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_authConnectRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest_string_view aeron_archive_client_authConnectRequest_get_responseChannel_as_string_view(
+    struct aeron_archive_client_authConnectRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_authConnectRequest_responseChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(
+        codec, aeron_archive_client_authConnectRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_authConnectRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_authConnectRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_put_responseChannel(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_authConnectRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_authConnectRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_encodedCredentials_meta_attribute(
+    const enum aeron_archive_client_authConnectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_authConnectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_authConnectRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_encodedCredentials_character_encoding(void)
+{
+    return "null";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_encodedCredentials_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_authConnectRequest_encodedCredentials_in_acting_version(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_authConnectRequest_encodedCredentials_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_authConnectRequest_encodedCredentials_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_encodedCredentials_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_authConnectRequest_encodedCredentials_length(
+    const struct aeron_archive_client_authConnectRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_authConnectRequest_encodedCredentials(
+    struct aeron_archive_client_authConnectRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(
+        codec, aeron_archive_client_authConnectRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_authConnectRequest_get_encodedCredentials(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_authConnectRequest_sbe_position(codec);
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_authConnectRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest_string_view aeron_archive_client_authConnectRequest_get_encodedCredentials_as_string_view(
+    struct aeron_archive_client_authConnectRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_authConnectRequest_encodedCredentials_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_authConnectRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(
+        codec, aeron_archive_client_authConnectRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_authConnectRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_authConnectRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_authConnectRequest *aeron_archive_client_authConnectRequest_put_encodedCredentials(
+    struct aeron_archive_client_authConnectRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_authConnectRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_authConnectRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_authConnectRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/booleanType.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/booleanType.h
@@ -1,0 +1,143 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_BOOLEANTYPE_H_
+#define _AERON_ARCHIVE_CLIENT_BOOLEANTYPE_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+enum aeron_archive_client_booleanType
+{
+    aeron_archive_client_booleanType_FALSE = INT32_C(0),
+    aeron_archive_client_booleanType_TRUE = INT32_C(1),
+    aeron_archive_client_booleanType_NULL_VALUE = INT32_MIN
+};
+
+SBE_ONE_DEF bool aeron_archive_client_booleanType_get(
+    const int32_t value,
+    enum aeron_archive_client_booleanType *const out)
+{
+    switch (value)
+    {
+        case INT32_C(0):
+             *out = aeron_archive_client_booleanType_FALSE;
+             return true;
+        case INT32_C(1):
+             *out = aeron_archive_client_booleanType_TRUE;
+             return true;
+        case INT32_MIN:
+             *out = aeron_archive_client_booleanType_NULL_VALUE;
+             return true;
+    }
+
+    errno = E103;
+    return false;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/boundedReplayRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/boundedReplayRequest.h
@@ -1,0 +1,1349 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_BOUNDEDREPLAYREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_BOUNDEDREPLAYREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_boundedReplayRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_boundedReplayRequest_meta_attribute
+{
+    aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH,
+    aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_boundedReplayRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_boundedReplayRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_boundedReplayRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_sbe_position(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_set_sbe_position(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_boundedReplayRequest_sbe_position_ptr(
+    struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_reset(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_boundedReplayRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_copy(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const struct aeron_archive_client_boundedReplayRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_sbe_block_length(void)
+{
+    return (uint16_t)60;
+}
+
+#define AERON_ARCHIVE_CLIENT_BOUNDED_REPLAY_REQUEST_SBE_TEMPLATE_ID (uint16_t)18
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_sbe_template_id(void)
+{
+    return (uint16_t)18;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_boundedReplayRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_offset(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_wrap_and_apply_header(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_boundedReplayRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_boundedReplayRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_boundedReplayRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_boundedReplayRequest_sbe_schema_version());
+
+    aeron_archive_client_boundedReplayRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_boundedReplayRequest_sbe_block_length(),
+        aeron_archive_client_boundedReplayRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_wrap_for_encode(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_boundedReplayRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_boundedReplayRequest_sbe_block_length(),
+        aeron_archive_client_boundedReplayRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_wrap_for_decode(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_boundedReplayRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_sbe_rewind(
+    struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return aeron_archive_client_boundedReplayRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_encoded_length(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return aeron_archive_client_boundedReplayRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_buffer(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_boundedReplayRequest_mut_buffer(
+    struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_buffer_length(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_controlSessionId(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_controlSessionId(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_correlationId(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_correlationId(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_recordingId(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_recordingId(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_position_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_position_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_position_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_position_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_position_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_position_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_position_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_position_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_position_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_position_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_position(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_position(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_length_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_length_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_length_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_length_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_length_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_length_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_length_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_length_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_length_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_length_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_length(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_length(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_limitCounterId_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_limitCounterId_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_limitCounterId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_limitCounterId_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_limitCounterId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_limitCounterId_encoding_offset(void)
+{
+    return 40;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_limitCounterId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_limitCounterId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_limitCounterId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_limitCounterId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_limitCounterId(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 40, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_limitCounterId(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 40, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_replayStreamId_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_replayStreamId_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_replayStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_replayStreamId_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_replayStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_replayStreamId_encoding_offset(void)
+{
+    return 44;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_replayStreamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_replayStreamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_replayStreamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_replayStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_replayStreamId(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 44, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_replayStreamId(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 44, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_fileIoMaxLength_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength_id(void)
+{
+    return 9;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength_since_version(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_fileIoMaxLength_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_fileIoMaxLength_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength_encoding_offset(void)
+{
+    return 48;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_boundedReplayRequest_fileIoMaxLength(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    if (codec->acting_version < 7)
+    {
+        return INT32_MIN;
+    }
+
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 48, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_fileIoMaxLength(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 48, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_replayToken_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_replayToken_id(void)
+{
+    return 10;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_replayToken_since_version(void)
+{
+    return 10;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_replayToken_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_replayToken_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_replayToken_encoding_offset(void)
+{
+    return 52;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_replayToken_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_replayToken_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_replayToken_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_boundedReplayRequest_replayToken_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_boundedReplayRequest_replayToken(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    if (codec->acting_version < 10)
+    {
+        return INT64_MIN;
+    }
+
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 52, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_set_replayToken(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 52, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_replayChannel_meta_attribute(
+    const enum aeron_archive_client_boundedReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_boundedReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_replayChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_replayChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_boundedReplayRequest_replayChannel_in_acting_version(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_boundedReplayRequest_replayChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_boundedReplayRequest_replayChannel_id(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_replayChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_boundedReplayRequest_replayChannel_length(
+    const struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_boundedReplayRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_boundedReplayRequest_replayChannel(
+    struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_boundedReplayRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_boundedReplayRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_boundedReplayRequest_set_sbe_position(
+        codec, aeron_archive_client_boundedReplayRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_boundedReplayRequest_get_replayChannel(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_boundedReplayRequest_sbe_position(codec);
+    if (!aeron_archive_client_boundedReplayRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_boundedReplayRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_boundedReplayRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest_string_view aeron_archive_client_boundedReplayRequest_get_replayChannel_as_string_view(
+    struct aeron_archive_client_boundedReplayRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_boundedReplayRequest_replayChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_boundedReplayRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_boundedReplayRequest_set_sbe_position(
+        codec, aeron_archive_client_boundedReplayRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_boundedReplayRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_boundedReplayRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_boundedReplayRequest *aeron_archive_client_boundedReplayRequest_put_replayChannel(
+    struct aeron_archive_client_boundedReplayRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_boundedReplayRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_boundedReplayRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_boundedReplayRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_boundedReplayRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/catalogHeader.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/catalogHeader.h
@@ -1,0 +1,824 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_CATALOGHEADER_H_
+#define _AERON_ARCHIVE_CLIENT_CATALOGHEADER_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_catalogHeader
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_catalogHeader_meta_attribute
+{
+    aeron_archive_client_catalogHeader_meta_attribute_EPOCH,
+    aeron_archive_client_catalogHeader_meta_attribute_TIME_UNIT,
+    aeron_archive_client_catalogHeader_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_catalogHeader_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_catalogHeader_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_catalogHeader_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_catalogHeader_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_sbe_position(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_catalogHeader_set_sbe_position(
+    struct aeron_archive_client_catalogHeader *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_catalogHeader_sbe_position_ptr(
+    struct aeron_archive_client_catalogHeader *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_reset(
+    struct aeron_archive_client_catalogHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_catalogHeader_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_copy(
+    struct aeron_archive_client_catalogHeader *const codec,
+    const struct aeron_archive_client_catalogHeader *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_CATALOG_HEADER_SBE_TEMPLATE_ID (uint16_t)20
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_sbe_template_id(void)
+{
+    return (uint16_t)20;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_catalogHeader_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_catalogHeader_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_offset(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_wrap_and_apply_header(
+    struct aeron_archive_client_catalogHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_catalogHeader_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_catalogHeader_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_catalogHeader_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_catalogHeader_sbe_schema_version());
+
+    aeron_archive_client_catalogHeader_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_catalogHeader_sbe_block_length(),
+        aeron_archive_client_catalogHeader_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_wrap_for_encode(
+    struct aeron_archive_client_catalogHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_catalogHeader_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_catalogHeader_sbe_block_length(),
+        aeron_archive_client_catalogHeader_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_wrap_for_decode(
+    struct aeron_archive_client_catalogHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_catalogHeader_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_sbe_rewind(
+    struct aeron_archive_client_catalogHeader *const codec)
+{
+    return aeron_archive_client_catalogHeader_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_encoded_length(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    return aeron_archive_client_catalogHeader_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_catalogHeader_buffer(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_catalogHeader_mut_buffer(
+    struct aeron_archive_client_catalogHeader *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_buffer_length(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_acting_version(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_catalogHeader_version_meta_attribute(
+    const enum aeron_archive_client_catalogHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_catalogHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_version_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_version_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_catalogHeader_version_in_acting_version(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_catalogHeader_version_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_version_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_version_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_version_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_version_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_version_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_version(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_set_version(
+    struct aeron_archive_client_catalogHeader *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_catalogHeader_length_meta_attribute(
+    const enum aeron_archive_client_catalogHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_catalogHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_length_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_length_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_catalogHeader_length_in_acting_version(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_catalogHeader_length_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_length_encoding_offset(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_length_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_length_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_length_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_length_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_length(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 4, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_set_length(
+    struct aeron_archive_client_catalogHeader *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 4, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_catalogHeader_nextRecordingId_meta_attribute(
+    const enum aeron_archive_client_catalogHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_catalogHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_nextRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_nextRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_catalogHeader_nextRecordingId_in_acting_version(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_catalogHeader_nextRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_nextRecordingId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_catalogHeader_nextRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_catalogHeader_nextRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_catalogHeader_nextRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_nextRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_catalogHeader_nextRecordingId(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_set_nextRecordingId(
+    struct aeron_archive_client_catalogHeader *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_catalogHeader_alignment_meta_attribute(
+    const enum aeron_archive_client_catalogHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_catalogHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_alignment_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_alignment_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_catalogHeader_alignment_in_acting_version(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_catalogHeader_alignment_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_alignment_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_alignment_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_alignment_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_alignment_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_alignment_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_catalogHeader_alignment(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_set_alignment(
+    struct aeron_archive_client_catalogHeader *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_catalogHeader_reserved_meta_attribute(
+    const enum aeron_archive_client_catalogHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_catalogHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_catalogHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_catalogHeader_reserved_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_catalogHeader_reserved_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_catalogHeader_reserved_in_acting_version(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_catalogHeader_reserved_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_reserved_encoding_offset(void)
+{
+    return 31;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_catalogHeader_reserved_null_value(void)
+{
+    return SBE_NULLVALUE_INT8;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_catalogHeader_reserved_min_value(void)
+{
+    return (int8_t)-127;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_catalogHeader_reserved_max_value(void)
+{
+    return (int8_t)127;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_catalogHeader_reserved_encoding_length(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_catalogHeader_reserved(
+    const struct aeron_archive_client_catalogHeader *const codec)
+{
+    int8_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 31, sizeof(int8_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return (val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_catalogHeader *aeron_archive_client_catalogHeader_set_reserved(
+    struct aeron_archive_client_catalogHeader *const codec,
+    const int8_t value)
+{
+    int8_t val = (value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 31, &val, sizeof(int8_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/challenge.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/challenge.h
@@ -1,0 +1,781 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_CHALLENGE_H_
+#define _AERON_ARCHIVE_CLIENT_CHALLENGE_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_challenge
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_challenge_meta_attribute
+{
+    aeron_archive_client_challenge_meta_attribute_EPOCH,
+    aeron_archive_client_challenge_meta_attribute_TIME_UNIT,
+    aeron_archive_client_challenge_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_challenge_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_challenge_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_challenge_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_challenge_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_sbe_position(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challenge_set_sbe_position(
+    struct aeron_archive_client_challenge *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_challenge_sbe_position_ptr(
+    struct aeron_archive_client_challenge *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_reset(
+    struct aeron_archive_client_challenge *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_challenge_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_copy(
+    struct aeron_archive_client_challenge *const codec,
+    const struct aeron_archive_client_challenge *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_sbe_block_length(void)
+{
+    return (uint16_t)20;
+}
+
+#define AERON_ARCHIVE_CLIENT_CHALLENGE_SBE_TEMPLATE_ID (uint16_t)59
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_sbe_template_id(void)
+{
+    return (uint16_t)59;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_challenge_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_offset(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_wrap_and_apply_header(
+    struct aeron_archive_client_challenge *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_challenge_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_challenge_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_challenge_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_challenge_sbe_schema_version());
+
+    aeron_archive_client_challenge_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_challenge_sbe_block_length(),
+        aeron_archive_client_challenge_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_wrap_for_encode(
+    struct aeron_archive_client_challenge *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_challenge_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_challenge_sbe_block_length(),
+        aeron_archive_client_challenge_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_wrap_for_decode(
+    struct aeron_archive_client_challenge *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_challenge_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_sbe_rewind(
+    struct aeron_archive_client_challenge *const codec)
+{
+    return aeron_archive_client_challenge_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_encoded_length(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    return aeron_archive_client_challenge_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_buffer(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_challenge_mut_buffer(
+    struct aeron_archive_client_challenge *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_buffer_length(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_acting_version(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_challenge_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_challenge_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_challenge_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_challenge_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_challenge_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challenge_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_challenge *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_challenge_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challenge_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challenge_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_controlSessionId(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_set_controlSessionId(
+    struct aeron_archive_client_challenge *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_correlationId_meta_attribute(
+    const enum aeron_archive_client_challenge_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_challenge_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_challenge_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_challenge_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_challenge_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challenge_correlationId_in_acting_version(
+    const struct aeron_archive_client_challenge *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_challenge_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challenge_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challenge_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challenge_correlationId(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_set_correlationId(
+    struct aeron_archive_client_challenge *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_version_meta_attribute(
+    const enum aeron_archive_client_challenge_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_challenge_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_challenge_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_challenge_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_challenge_meta_attribute_PRESENCE: return "optional";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_version_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_version_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challenge_version_in_acting_version(
+    const struct aeron_archive_client_challenge *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_challenge_version_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challenge_version_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_challenge_version_null_value(void)
+{
+    return INT32_C(0);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_challenge_version_min_value(void)
+{
+    return INT32_C(2);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_challenge_version_max_value(void)
+{
+    return INT32_C(16777215);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challenge_version_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_challenge_version(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_set_version(
+    struct aeron_archive_client_challenge *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_encodedChallenge_meta_attribute(
+    const enum aeron_archive_client_challenge_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_challenge_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_challenge_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_challenge_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_challenge_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_encodedChallenge_character_encoding(void)
+{
+    return "null";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_encodedChallenge_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challenge_encodedChallenge_in_acting_version(
+    const struct aeron_archive_client_challenge *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_challenge_encodedChallenge_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challenge_encodedChallenge_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_encodedChallenge_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_challenge_encodedChallenge_length(
+    const struct aeron_archive_client_challenge *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_challenge_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challenge_encodedChallenge(
+    struct aeron_archive_client_challenge *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_challenge_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_challenge_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_challenge_set_sbe_position(
+        codec, aeron_archive_client_challenge_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challenge_get_encodedChallenge(
+    struct aeron_archive_client_challenge *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_challenge_sbe_position(codec);
+    if (!aeron_archive_client_challenge_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_challenge_sbe_position(codec);
+
+    if (!aeron_archive_client_challenge_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge_string_view aeron_archive_client_challenge_get_encodedChallenge_as_string_view(
+    struct aeron_archive_client_challenge *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_challenge_encodedChallenge_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_challenge_sbe_position(codec) + 4;
+    if (!aeron_archive_client_challenge_set_sbe_position(
+        codec, aeron_archive_client_challenge_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_challenge_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_challenge_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challenge *aeron_archive_client_challenge_put_encodedChallenge(
+    struct aeron_archive_client_challenge *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_challenge_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_challenge_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_challenge_sbe_position(codec);
+
+    if (!aeron_archive_client_challenge_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/challengeResponse.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/challengeResponse.h
@@ -1,0 +1,688 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_CHALLENGERESPONSE_H_
+#define _AERON_ARCHIVE_CLIENT_CHALLENGERESPONSE_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_challengeResponse
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_challengeResponse_meta_attribute
+{
+    aeron_archive_client_challengeResponse_meta_attribute_EPOCH,
+    aeron_archive_client_challengeResponse_meta_attribute_TIME_UNIT,
+    aeron_archive_client_challengeResponse_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_challengeResponse_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_challengeResponse_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_challengeResponse_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_challengeResponse_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_sbe_position(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challengeResponse_set_sbe_position(
+    struct aeron_archive_client_challengeResponse *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_challengeResponse_sbe_position_ptr(
+    struct aeron_archive_client_challengeResponse *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_reset(
+    struct aeron_archive_client_challengeResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_challengeResponse_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_copy(
+    struct aeron_archive_client_challengeResponse *const codec,
+    const struct aeron_archive_client_challengeResponse *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challengeResponse_sbe_block_length(void)
+{
+    return (uint16_t)16;
+}
+
+#define AERON_ARCHIVE_CLIENT_CHALLENGE_RESPONSE_SBE_TEMPLATE_ID (uint16_t)60
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challengeResponse_sbe_template_id(void)
+{
+    return (uint16_t)60;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challengeResponse_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challengeResponse_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_challengeResponse_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challengeResponse_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_offset(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_wrap_and_apply_header(
+    struct aeron_archive_client_challengeResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_challengeResponse_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_challengeResponse_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_challengeResponse_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_challengeResponse_sbe_schema_version());
+
+    aeron_archive_client_challengeResponse_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_challengeResponse_sbe_block_length(),
+        aeron_archive_client_challengeResponse_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_wrap_for_encode(
+    struct aeron_archive_client_challengeResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_challengeResponse_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_challengeResponse_sbe_block_length(),
+        aeron_archive_client_challengeResponse_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_wrap_for_decode(
+    struct aeron_archive_client_challengeResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_challengeResponse_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_sbe_rewind(
+    struct aeron_archive_client_challengeResponse *const codec)
+{
+    return aeron_archive_client_challengeResponse_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_encoded_length(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    return aeron_archive_client_challengeResponse_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challengeResponse_buffer(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_challengeResponse_mut_buffer(
+    struct aeron_archive_client_challengeResponse *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_buffer_length(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_acting_version(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challengeResponse_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_challengeResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_challengeResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challengeResponse_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challengeResponse_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_challengeResponse_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challengeResponse_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challengeResponse_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_controlSessionId(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_set_controlSessionId(
+    struct aeron_archive_client_challengeResponse *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challengeResponse_correlationId_meta_attribute(
+    const enum aeron_archive_client_challengeResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_challengeResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challengeResponse_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challengeResponse_correlationId_in_acting_version(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_challengeResponse_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challengeResponse_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_challengeResponse_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_challengeResponse_correlationId(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_set_correlationId(
+    struct aeron_archive_client_challengeResponse *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challengeResponse_encodedCredentials_meta_attribute(
+    const enum aeron_archive_client_challengeResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_challengeResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_challengeResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challengeResponse_encodedCredentials_character_encoding(void)
+{
+    return "null";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_encodedCredentials_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_challengeResponse_encodedCredentials_in_acting_version(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_challengeResponse_encodedCredentials_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_challengeResponse_encodedCredentials_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_encodedCredentials_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_challengeResponse_encodedCredentials_length(
+    const struct aeron_archive_client_challengeResponse *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_challengeResponse_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_challengeResponse_encodedCredentials(
+    struct aeron_archive_client_challengeResponse *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_challengeResponse_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_challengeResponse_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_challengeResponse_set_sbe_position(
+        codec, aeron_archive_client_challengeResponse_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_challengeResponse_get_encodedCredentials(
+    struct aeron_archive_client_challengeResponse *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_challengeResponse_sbe_position(codec);
+    if (!aeron_archive_client_challengeResponse_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_challengeResponse_sbe_position(codec);
+
+    if (!aeron_archive_client_challengeResponse_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse_string_view aeron_archive_client_challengeResponse_get_encodedCredentials_as_string_view(
+    struct aeron_archive_client_challengeResponse *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_challengeResponse_encodedCredentials_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_challengeResponse_sbe_position(codec) + 4;
+    if (!aeron_archive_client_challengeResponse_set_sbe_position(
+        codec, aeron_archive_client_challengeResponse_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_challengeResponse_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_challengeResponse_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_challengeResponse *aeron_archive_client_challengeResponse_put_encodedCredentials(
+    struct aeron_archive_client_challengeResponse *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_challengeResponse_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_challengeResponse_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_challengeResponse_sbe_position(codec);
+
+    if (!aeron_archive_client_challengeResponse_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/closeSessionRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/closeSessionRequest.h
@@ -1,0 +1,452 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_CLOSESESSIONREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_CLOSESESSIONREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_closeSessionRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_closeSessionRequest_meta_attribute
+{
+    aeron_archive_client_closeSessionRequest_meta_attribute_EPOCH,
+    aeron_archive_client_closeSessionRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_closeSessionRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_closeSessionRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_closeSessionRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_closeSessionRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_closeSessionRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_closeSessionRequest_sbe_position(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_closeSessionRequest_set_sbe_position(
+    struct aeron_archive_client_closeSessionRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_closeSessionRequest_sbe_position_ptr(
+    struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_closeSessionRequest *aeron_archive_client_closeSessionRequest_reset(
+    struct aeron_archive_client_closeSessionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_closeSessionRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_closeSessionRequest *aeron_archive_client_closeSessionRequest_copy(
+    struct aeron_archive_client_closeSessionRequest *const codec,
+    const struct aeron_archive_client_closeSessionRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_closeSessionRequest_sbe_block_length(void)
+{
+    return (uint16_t)8;
+}
+
+#define AERON_ARCHIVE_CLIENT_CLOSE_SESSION_REQUEST_SBE_TEMPLATE_ID (uint16_t)3
+
+SBE_ONE_DEF uint16_t aeron_archive_client_closeSessionRequest_sbe_template_id(void)
+{
+    return (uint16_t)3;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_closeSessionRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_closeSessionRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_closeSessionRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_closeSessionRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_closeSessionRequest_offset(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_closeSessionRequest *aeron_archive_client_closeSessionRequest_wrap_and_apply_header(
+    struct aeron_archive_client_closeSessionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_closeSessionRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_closeSessionRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_closeSessionRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_closeSessionRequest_sbe_schema_version());
+
+    aeron_archive_client_closeSessionRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_closeSessionRequest_sbe_block_length(),
+        aeron_archive_client_closeSessionRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_closeSessionRequest *aeron_archive_client_closeSessionRequest_wrap_for_encode(
+    struct aeron_archive_client_closeSessionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_closeSessionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_closeSessionRequest_sbe_block_length(),
+        aeron_archive_client_closeSessionRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_closeSessionRequest *aeron_archive_client_closeSessionRequest_wrap_for_decode(
+    struct aeron_archive_client_closeSessionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_closeSessionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_closeSessionRequest *aeron_archive_client_closeSessionRequest_sbe_rewind(
+    struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return aeron_archive_client_closeSessionRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_closeSessionRequest_encoded_length(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return aeron_archive_client_closeSessionRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_closeSessionRequest_buffer(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_closeSessionRequest_mut_buffer(
+    struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_closeSessionRequest_buffer_length(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_closeSessionRequest_acting_version(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_closeSessionRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_closeSessionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_closeSessionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_closeSessionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_closeSessionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_closeSessionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_closeSessionRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_closeSessionRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_closeSessionRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_closeSessionRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_closeSessionRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_closeSessionRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_closeSessionRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_closeSessionRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_closeSessionRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_closeSessionRequest_controlSessionId(
+    const struct aeron_archive_client_closeSessionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_closeSessionRequest *aeron_archive_client_closeSessionRequest_set_controlSessionId(
+    struct aeron_archive_client_closeSessionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/connectRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/connectRequest.h
@@ -1,0 +1,786 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_CONNECTREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_CONNECTREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_connectRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_connectRequest_meta_attribute
+{
+    aeron_archive_client_connectRequest_meta_attribute_EPOCH,
+    aeron_archive_client_connectRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_connectRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_connectRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_connectRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_connectRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_connectRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_sbe_position(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_connectRequest_set_sbe_position(
+    struct aeron_archive_client_connectRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_connectRequest_sbe_position_ptr(
+    struct aeron_archive_client_connectRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_reset(
+    struct aeron_archive_client_connectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_connectRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_copy(
+    struct aeron_archive_client_connectRequest *const codec,
+    const struct aeron_archive_client_connectRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_sbe_block_length(void)
+{
+    return (uint16_t)16;
+}
+
+#define AERON_ARCHIVE_CLIENT_CONNECT_REQUEST_SBE_TEMPLATE_ID (uint16_t)2
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_sbe_template_id(void)
+{
+    return (uint16_t)2;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_connectRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_offset(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_wrap_and_apply_header(
+    struct aeron_archive_client_connectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_connectRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_connectRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_connectRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_connectRequest_sbe_schema_version());
+
+    aeron_archive_client_connectRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_connectRequest_sbe_block_length(),
+        aeron_archive_client_connectRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_wrap_for_encode(
+    struct aeron_archive_client_connectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_connectRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_connectRequest_sbe_block_length(),
+        aeron_archive_client_connectRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_wrap_for_decode(
+    struct aeron_archive_client_connectRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_connectRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_sbe_rewind(
+    struct aeron_archive_client_connectRequest *const codec)
+{
+    return aeron_archive_client_connectRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_encoded_length(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    return aeron_archive_client_connectRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_buffer(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_connectRequest_mut_buffer(
+    struct aeron_archive_client_connectRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_buffer_length(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_acting_version(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_connectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_connectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_correlationId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_connectRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_connectRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_connectRequest_correlationId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_connectRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_connectRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_connectRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_connectRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_connectRequest_correlationId(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_set_correlationId(
+    struct aeron_archive_client_connectRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_responseStreamId_meta_attribute(
+    const enum aeron_archive_client_connectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_connectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_responseStreamId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_responseStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_connectRequest_responseStreamId_in_acting_version(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_connectRequest_responseStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_connectRequest_responseStreamId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_responseStreamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_responseStreamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_responseStreamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_connectRequest_responseStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_responseStreamId(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_set_responseStreamId(
+    struct aeron_archive_client_connectRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_version_meta_attribute(
+    const enum aeron_archive_client_connectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_connectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_PRESENCE: return "optional";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_version_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_version_since_version(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_connectRequest_version_in_acting_version(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_connectRequest_version_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_connectRequest_version_encoding_offset(void)
+{
+    return 12;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_version_null_value(void)
+{
+    return INT32_C(0);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_version_min_value(void)
+{
+    return INT32_C(2);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_version_max_value(void)
+{
+    return INT32_C(16777215);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_connectRequest_version_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_connectRequest_version(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    if (codec->acting_version < 2)
+    {
+        return INT32_C(0);
+    }
+
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 12, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_set_version(
+    struct aeron_archive_client_connectRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 12, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_responseChannel_meta_attribute(
+    const enum aeron_archive_client_connectRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_connectRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_connectRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_responseChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_responseChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_connectRequest_responseChannel_in_acting_version(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_connectRequest_responseChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_connectRequest_responseChannel_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_responseChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_connectRequest_responseChannel_length(
+    const struct aeron_archive_client_connectRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_connectRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_connectRequest_responseChannel(
+    struct aeron_archive_client_connectRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_connectRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_connectRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_connectRequest_set_sbe_position(
+        codec, aeron_archive_client_connectRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_connectRequest_get_responseChannel(
+    struct aeron_archive_client_connectRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_connectRequest_sbe_position(codec);
+    if (!aeron_archive_client_connectRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_connectRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_connectRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest_string_view aeron_archive_client_connectRequest_get_responseChannel_as_string_view(
+    struct aeron_archive_client_connectRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_connectRequest_responseChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_connectRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_connectRequest_set_sbe_position(
+        codec, aeron_archive_client_connectRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_connectRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_connectRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_connectRequest *aeron_archive_client_connectRequest_put_responseChannel(
+    struct aeron_archive_client_connectRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_connectRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_connectRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_connectRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_connectRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/controlResponse.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/controlResponse.h
@@ -1,0 +1,946 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_CONTROLRESPONSE_H_
+#define _AERON_ARCHIVE_CLIENT_CONTROLRESPONSE_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_controlResponse
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_controlResponse_meta_attribute
+{
+    aeron_archive_client_controlResponse_meta_attribute_EPOCH,
+    aeron_archive_client_controlResponse_meta_attribute_TIME_UNIT,
+    aeron_archive_client_controlResponse_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_controlResponse_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_controlResponse_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_controlResponse_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_controlResponse_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_sbe_position(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_set_sbe_position(
+    struct aeron_archive_client_controlResponse *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_controlResponse_sbe_position_ptr(
+    struct aeron_archive_client_controlResponse *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_reset(
+    struct aeron_archive_client_controlResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_controlResponse_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_copy(
+    struct aeron_archive_client_controlResponse *const codec,
+    const struct aeron_archive_client_controlResponse *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_CONTROL_RESPONSE_SBE_TEMPLATE_ID (uint16_t)1
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_sbe_template_id(void)
+{
+    return (uint16_t)1;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_controlResponse_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_offset(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_wrap_and_apply_header(
+    struct aeron_archive_client_controlResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_controlResponse_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_controlResponse_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_controlResponse_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_controlResponse_sbe_schema_version());
+
+    aeron_archive_client_controlResponse_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_controlResponse_sbe_block_length(),
+        aeron_archive_client_controlResponse_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_wrap_for_encode(
+    struct aeron_archive_client_controlResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_controlResponse_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_controlResponse_sbe_block_length(),
+        aeron_archive_client_controlResponse_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_wrap_for_decode(
+    struct aeron_archive_client_controlResponse *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_controlResponse_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_sbe_rewind(
+    struct aeron_archive_client_controlResponse *const codec)
+{
+    return aeron_archive_client_controlResponse_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_encoded_length(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    return aeron_archive_client_controlResponse_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_buffer(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_controlResponse_mut_buffer(
+    struct aeron_archive_client_controlResponse *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_buffer_length(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_acting_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_controlResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_controlResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_controlResponse_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_controlSessionId(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_set_controlSessionId(
+    struct aeron_archive_client_controlResponse *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_correlationId_meta_attribute(
+    const enum aeron_archive_client_controlResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_controlResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_correlationId_in_acting_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_controlResponse_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_correlationId(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_set_correlationId(
+    struct aeron_archive_client_controlResponse *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_relevantId_meta_attribute(
+    const enum aeron_archive_client_controlResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_controlResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_relevantId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_relevantId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_relevantId_in_acting_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_controlResponse_relevantId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_relevantId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_relevantId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_relevantId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_relevantId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_relevantId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_controlResponse_relevantId(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_set_relevantId(
+    struct aeron_archive_client_controlResponse *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_code_meta_attribute(
+    const enum aeron_archive_client_controlResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_controlResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_code_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_code_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_code_in_acting_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_controlResponse_code_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_code_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_code_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_code(
+    const struct aeron_archive_client_controlResponse *const codec,
+    enum aeron_archive_client_controlResponseCode *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+
+    return aeron_archive_client_controlResponseCode_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_set_code(
+    struct aeron_archive_client_controlResponse *const codec,
+    const enum aeron_archive_client_controlResponseCode value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_version_meta_attribute(
+    const enum aeron_archive_client_controlResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_controlResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_PRESENCE: return "optional";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_version_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_version_since_version(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_version_in_acting_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_controlResponse_version_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_version_encoding_offset(void)
+{
+    return 28;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_controlResponse_version_null_value(void)
+{
+    return INT32_C(0);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_controlResponse_version_min_value(void)
+{
+    return INT32_C(2);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_controlResponse_version_max_value(void)
+{
+    return INT32_C(16777215);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_controlResponse_version_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_controlResponse_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    if (codec->acting_version < 4)
+    {
+        return INT32_C(0);
+    }
+
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 28, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_set_version(
+    struct aeron_archive_client_controlResponse *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 28, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_errorMessage_meta_attribute(
+    const enum aeron_archive_client_controlResponse_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_controlResponse_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_controlResponse_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_errorMessage_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_errorMessage_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponse_errorMessage_in_acting_version(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_controlResponse_errorMessage_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_controlResponse_errorMessage_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_errorMessage_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_controlResponse_errorMessage_length(
+    const struct aeron_archive_client_controlResponse *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_controlResponse_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_controlResponse_errorMessage(
+    struct aeron_archive_client_controlResponse *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_controlResponse_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_controlResponse_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_controlResponse_set_sbe_position(
+        codec, aeron_archive_client_controlResponse_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_controlResponse_get_errorMessage(
+    struct aeron_archive_client_controlResponse *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_controlResponse_sbe_position(codec);
+    if (!aeron_archive_client_controlResponse_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_controlResponse_sbe_position(codec);
+
+    if (!aeron_archive_client_controlResponse_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse_string_view aeron_archive_client_controlResponse_get_errorMessage_as_string_view(
+    struct aeron_archive_client_controlResponse *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_controlResponse_errorMessage_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_controlResponse_sbe_position(codec) + 4;
+    if (!aeron_archive_client_controlResponse_set_sbe_position(
+        codec, aeron_archive_client_controlResponse_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_controlResponse_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_controlResponse_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_controlResponse *aeron_archive_client_controlResponse_put_errorMessage(
+    struct aeron_archive_client_controlResponse *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_controlResponse_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_controlResponse_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_controlResponse_sbe_position(codec);
+
+    if (!aeron_archive_client_controlResponse_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/controlResponseCode.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/controlResponseCode.h
@@ -1,0 +1,151 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_CONTROLRESPONSECODE_H_
+#define _AERON_ARCHIVE_CLIENT_CONTROLRESPONSECODE_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+enum aeron_archive_client_controlResponseCode
+{
+    aeron_archive_client_controlResponseCode_OK = INT32_C(0),
+    aeron_archive_client_controlResponseCode_ERROR = INT32_C(1),
+    aeron_archive_client_controlResponseCode_RECORDING_UNKNOWN = INT32_C(2),
+    aeron_archive_client_controlResponseCode_SUBSCRIPTION_UNKNOWN = INT32_C(3),
+    aeron_archive_client_controlResponseCode_NULL_VALUE = INT32_MIN
+};
+
+SBE_ONE_DEF bool aeron_archive_client_controlResponseCode_get(
+    const int32_t value,
+    enum aeron_archive_client_controlResponseCode *const out)
+{
+    switch (value)
+    {
+        case INT32_C(0):
+             *out = aeron_archive_client_controlResponseCode_OK;
+             return true;
+        case INT32_C(1):
+             *out = aeron_archive_client_controlResponseCode_ERROR;
+             return true;
+        case INT32_C(2):
+             *out = aeron_archive_client_controlResponseCode_RECORDING_UNKNOWN;
+             return true;
+        case INT32_C(3):
+             *out = aeron_archive_client_controlResponseCode_SUBSCRIPTION_UNKNOWN;
+             return true;
+        case INT32_MIN:
+             *out = aeron_archive_client_controlResponseCode_NULL_VALUE;
+             return true;
+    }
+
+    errno = E103;
+    return false;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/deleteDetachedSegmentsRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/deleteDetachedSegmentsRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_DELETEDETACHEDSEGMENTSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_DELETEDETACHEDSEGMENTSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_deleteDetachedSegmentsRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute
+{
+    aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_EPOCH,
+    aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_deleteDetachedSegmentsRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_deleteDetachedSegmentsRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_deleteDetachedSegmentsRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_sbe_position(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_deleteDetachedSegmentsRequest_set_sbe_position(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_deleteDetachedSegmentsRequest_sbe_position_ptr(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_reset(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_deleteDetachedSegmentsRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_copy(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_deleteDetachedSegmentsRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_DELETE_DETACHED_SEGMENTS_REQUEST_SBE_TEMPLATE_ID (uint16_t)54
+
+SBE_ONE_DEF uint16_t aeron_archive_client_deleteDetachedSegmentsRequest_sbe_template_id(void)
+{
+    return (uint16_t)54;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_deleteDetachedSegmentsRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_deleteDetachedSegmentsRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_deleteDetachedSegmentsRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_deleteDetachedSegmentsRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_offset(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_wrap_and_apply_header(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_deleteDetachedSegmentsRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_deleteDetachedSegmentsRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_deleteDetachedSegmentsRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_deleteDetachedSegmentsRequest_sbe_schema_version());
+
+    aeron_archive_client_deleteDetachedSegmentsRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_deleteDetachedSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_deleteDetachedSegmentsRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_wrap_for_encode(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_deleteDetachedSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_deleteDetachedSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_deleteDetachedSegmentsRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_wrap_for_decode(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_deleteDetachedSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_sbe_rewind(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return aeron_archive_client_deleteDetachedSegmentsRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_encoded_length(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return aeron_archive_client_deleteDetachedSegmentsRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_deleteDetachedSegmentsRequest_buffer(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_deleteDetachedSegmentsRequest_mut_buffer(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_buffer_length(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_acting_version(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_controlSessionId(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_set_controlSessionId(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_correlationId(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_set_correlationId(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_deleteDetachedSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_deleteDetachedSegmentsRequest_recordingId(
+    const struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_deleteDetachedSegmentsRequest *aeron_archive_client_deleteDetachedSegmentsRequest_set_recordingId(
+    struct aeron_archive_client_deleteDetachedSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/detachSegmentsRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/detachSegmentsRequest.h
@@ -1,0 +1,731 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_DETACHSEGMENTSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_DETACHSEGMENTSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_detachSegmentsRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_detachSegmentsRequest_meta_attribute
+{
+    aeron_archive_client_detachSegmentsRequest_meta_attribute_EPOCH,
+    aeron_archive_client_detachSegmentsRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_detachSegmentsRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_detachSegmentsRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_detachSegmentsRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_detachSegmentsRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_detachSegmentsRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_sbe_position(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_detachSegmentsRequest_set_sbe_position(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_detachSegmentsRequest_sbe_position_ptr(
+    struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_reset(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_detachSegmentsRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_copy(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    const struct aeron_archive_client_detachSegmentsRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_DETACH_SEGMENTS_REQUEST_SBE_TEMPLATE_ID (uint16_t)53
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_sbe_template_id(void)
+{
+    return (uint16_t)53;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_detachSegmentsRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_detachSegmentsRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_offset(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_wrap_and_apply_header(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_detachSegmentsRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_detachSegmentsRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_detachSegmentsRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_detachSegmentsRequest_sbe_schema_version());
+
+    aeron_archive_client_detachSegmentsRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_detachSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_detachSegmentsRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_wrap_for_encode(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_detachSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_detachSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_detachSegmentsRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_wrap_for_decode(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_detachSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_sbe_rewind(
+    struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return aeron_archive_client_detachSegmentsRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_encoded_length(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return aeron_archive_client_detachSegmentsRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_detachSegmentsRequest_buffer(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_detachSegmentsRequest_mut_buffer(
+    struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_buffer_length(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_acting_version(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_detachSegmentsRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_detachSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_detachSegmentsRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_detachSegmentsRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_controlSessionId(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_set_controlSessionId(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_detachSegmentsRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_detachSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_detachSegmentsRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_detachSegmentsRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_correlationId(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_set_correlationId(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_detachSegmentsRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_detachSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_detachSegmentsRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_detachSegmentsRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_recordingId(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_set_recordingId(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_detachSegmentsRequest_newStartPosition_meta_attribute(
+    const enum aeron_archive_client_detachSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_detachSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_detachSegmentsRequest_newStartPosition_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_detachSegmentsRequest_newStartPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_detachSegmentsRequest_newStartPosition_in_acting_version(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_detachSegmentsRequest_newStartPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_newStartPosition_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_newStartPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_newStartPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_newStartPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_detachSegmentsRequest_newStartPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_detachSegmentsRequest_newStartPosition(
+    const struct aeron_archive_client_detachSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_detachSegmentsRequest *aeron_archive_client_detachSegmentsRequest_set_newStartPosition(
+    struct aeron_archive_client_detachSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/extendRecordingRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/extendRecordingRequest.h
@@ -1,0 +1,941 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_EXTENDRECORDINGREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_EXTENDRECORDINGREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_extendRecordingRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_extendRecordingRequest_meta_attribute
+{
+    aeron_archive_client_extendRecordingRequest_meta_attribute_EPOCH,
+    aeron_archive_client_extendRecordingRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_extendRecordingRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_extendRecordingRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_extendRecordingRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_extendRecordingRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_extendRecordingRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_sbe_position(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_set_sbe_position(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_extendRecordingRequest_sbe_position_ptr(
+    struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_reset(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_extendRecordingRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_copy(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const struct aeron_archive_client_extendRecordingRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_EXTEND_RECORDING_REQUEST_SBE_TEMPLATE_ID (uint16_t)11
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_sbe_template_id(void)
+{
+    return (uint16_t)11;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_extendRecordingRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_offset(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_wrap_and_apply_header(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_extendRecordingRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_extendRecordingRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_extendRecordingRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_extendRecordingRequest_sbe_schema_version());
+
+    aeron_archive_client_extendRecordingRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_extendRecordingRequest_sbe_block_length(),
+        aeron_archive_client_extendRecordingRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_wrap_for_encode(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_extendRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_extendRecordingRequest_sbe_block_length(),
+        aeron_archive_client_extendRecordingRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_wrap_for_decode(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_extendRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_sbe_rewind(
+    struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return aeron_archive_client_extendRecordingRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_encoded_length(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return aeron_archive_client_extendRecordingRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_buffer(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_extendRecordingRequest_mut_buffer(
+    struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_buffer_length(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_controlSessionId(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_set_controlSessionId(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_correlationId(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_set_correlationId(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest_recordingId(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_set_recordingId(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_streamId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_streamId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_streamId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_streamId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest_streamId(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_set_streamId(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_sourceLocation_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_sourceLocation_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_sourceLocation_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_sourceLocation_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest_sourceLocation_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_sourceLocation_encoding_offset(void)
+{
+    return 28;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest_sourceLocation_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_sourceLocation(
+    const struct aeron_archive_client_extendRecordingRequest *const codec,
+    enum aeron_archive_client_sourceLocation *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 28, sizeof(int32_t));
+
+    return aeron_archive_client_sourceLocation_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_set_sourceLocation(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const enum aeron_archive_client_sourceLocation value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 28, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_channel_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest_channel_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest_channel_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_extendRecordingRequest_channel_length(
+    const struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_extendRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest_channel(
+    struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_extendRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_extendRecordingRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_extendRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_extendRecordingRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest_get_channel(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_extendRecordingRequest_sbe_position(codec);
+    if (!aeron_archive_client_extendRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_extendRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_extendRecordingRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest_string_view aeron_archive_client_extendRecordingRequest_get_channel_as_string_view(
+    struct aeron_archive_client_extendRecordingRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_extendRecordingRequest_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_extendRecordingRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_extendRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_extendRecordingRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_extendRecordingRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_extendRecordingRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest *aeron_archive_client_extendRecordingRequest_put_channel(
+    struct aeron_archive_client_extendRecordingRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_extendRecordingRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_extendRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_extendRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_extendRecordingRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/extendRecordingRequest2.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/extendRecordingRequest2.h
@@ -1,0 +1,1008 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_EXTENDRECORDINGREQUEST2_H_
+#define _AERON_ARCHIVE_CLIENT_EXTENDRECORDINGREQUEST2_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_extendRecordingRequest2
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_extendRecordingRequest2_meta_attribute
+{
+    aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH,
+    aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT,
+    aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_extendRecordingRequest2_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_extendRecordingRequest2_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_extendRecordingRequest2_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_sbe_position(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_set_sbe_position(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_extendRecordingRequest2_sbe_position_ptr(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_reset(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_extendRecordingRequest2_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_copy(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const struct aeron_archive_client_extendRecordingRequest2 *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_sbe_block_length(void)
+{
+    return (uint16_t)36;
+}
+
+#define AERON_ARCHIVE_CLIENT_EXTEND_RECORDING_REQUEST2_SBE_TEMPLATE_ID (uint16_t)64
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_sbe_template_id(void)
+{
+    return (uint16_t)64;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_extendRecordingRequest2_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_offset(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_wrap_and_apply_header(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_extendRecordingRequest2_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_extendRecordingRequest2_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_extendRecordingRequest2_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_extendRecordingRequest2_sbe_schema_version());
+
+    aeron_archive_client_extendRecordingRequest2_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_extendRecordingRequest2_sbe_block_length(),
+        aeron_archive_client_extendRecordingRequest2_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_wrap_for_encode(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_extendRecordingRequest2_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_extendRecordingRequest2_sbe_block_length(),
+        aeron_archive_client_extendRecordingRequest2_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_wrap_for_decode(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_extendRecordingRequest2_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_sbe_rewind(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return aeron_archive_client_extendRecordingRequest2_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_encoded_length(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return aeron_archive_client_extendRecordingRequest2_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_buffer(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_extendRecordingRequest2_mut_buffer(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_buffer_length(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest2_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_controlSessionId(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_set_controlSessionId(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_correlationId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_correlationId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest2_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_correlationId(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_set_correlationId(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_recordingId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_recordingId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest2_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_extendRecordingRequest2_recordingId(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_set_recordingId(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_streamId_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_streamId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_streamId_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest2_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_streamId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest2_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest2_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest2_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_extendRecordingRequest2_streamId(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_set_streamId(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_sourceLocation_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_sourceLocation_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_sourceLocation_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_sourceLocation_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest2_sourceLocation_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_sourceLocation_encoding_offset(void)
+{
+    return 28;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_sourceLocation_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_sourceLocation(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    enum aeron_archive_client_sourceLocation *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 28, sizeof(int32_t));
+
+    return aeron_archive_client_sourceLocation_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_set_sourceLocation(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const enum aeron_archive_client_sourceLocation value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 28, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_autoStop_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_autoStop_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_autoStop_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_autoStop_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest2_autoStop_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_autoStop_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_extendRecordingRequest2_autoStop_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_autoStop(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    enum aeron_archive_client_booleanType *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int32_t));
+
+    return aeron_archive_client_booleanType_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_set_autoStop(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const enum aeron_archive_client_booleanType value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_channel_meta_attribute(
+    const enum aeron_archive_client_extendRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_extendRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_extendRecordingRequest2_channel_in_acting_version(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_extendRecordingRequest2_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_extendRecordingRequest2_channel_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_extendRecordingRequest2_channel_length(
+    const struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_extendRecordingRequest2_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_extendRecordingRequest2_channel(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_extendRecordingRequest2_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_extendRecordingRequest2_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_extendRecordingRequest2_set_sbe_position(
+        codec, aeron_archive_client_extendRecordingRequest2_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_extendRecordingRequest2_get_channel(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_extendRecordingRequest2_sbe_position(codec);
+    if (!aeron_archive_client_extendRecordingRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_extendRecordingRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_extendRecordingRequest2_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2_string_view aeron_archive_client_extendRecordingRequest2_get_channel_as_string_view(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_extendRecordingRequest2_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_extendRecordingRequest2_sbe_position(codec) + 4;
+    if (!aeron_archive_client_extendRecordingRequest2_set_sbe_position(
+        codec, aeron_archive_client_extendRecordingRequest2_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_extendRecordingRequest2_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_extendRecordingRequest2_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_extendRecordingRequest2 *aeron_archive_client_extendRecordingRequest2_put_channel(
+    struct aeron_archive_client_extendRecordingRequest2 *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_extendRecordingRequest2_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_extendRecordingRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_extendRecordingRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_extendRecordingRequest2_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/findLastMatchingRecordingRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/findLastMatchingRecordingRequest.h
@@ -1,0 +1,967 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_FINDLASTMATCHINGRECORDINGREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_FINDLASTMATCHINGRECORDINGREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_findLastMatchingRecordingRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute
+{
+    aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_EPOCH,
+    aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_findLastMatchingRecordingRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_findLastMatchingRecordingRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_findLastMatchingRecordingRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_findLastMatchingRecordingRequest_sbe_position_ptr(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_reset(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_copy(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_FIND_LAST_MATCHING_RECORDING_REQUEST_SBE_TEMPLATE_ID (uint16_t)16
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_sbe_template_id(void)
+{
+    return (uint16_t)16;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_findLastMatchingRecordingRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_offset(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_wrap_and_apply_header(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_findLastMatchingRecordingRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_findLastMatchingRecordingRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_findLastMatchingRecordingRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_findLastMatchingRecordingRequest_sbe_schema_version());
+
+    aeron_archive_client_findLastMatchingRecordingRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_findLastMatchingRecordingRequest_sbe_block_length(),
+        aeron_archive_client_findLastMatchingRecordingRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_wrap_for_encode(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_findLastMatchingRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_findLastMatchingRecordingRequest_sbe_block_length(),
+        aeron_archive_client_findLastMatchingRecordingRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_wrap_for_decode(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_findLastMatchingRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_sbe_rewind(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return aeron_archive_client_findLastMatchingRecordingRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_encoded_length(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_buffer(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_findLastMatchingRecordingRequest_mut_buffer(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_buffer_length(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_acting_version(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_controlSessionId(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_set_controlSessionId(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_findLastMatchingRecordingRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_findLastMatchingRecordingRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_correlationId(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_set_correlationId(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_meta_attribute(
+    const enum aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_in_acting_version(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_findLastMatchingRecordingRequest_minRecordingId(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_set_minRecordingId(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_sessionId_meta_attribute(
+    const enum aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_findLastMatchingRecordingRequest_sessionId_in_acting_version(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_findLastMatchingRecordingRequest_sessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_sessionId(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_set_sessionId(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_streamId_meta_attribute(
+    const enum aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_streamId_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_findLastMatchingRecordingRequest_streamId_in_acting_version(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_findLastMatchingRecordingRequest_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_streamId_encoding_offset(void)
+{
+    return 28;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_findLastMatchingRecordingRequest_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_findLastMatchingRecordingRequest_streamId(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 28, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_set_streamId(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 28, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_channel_meta_attribute(
+    const enum aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_findLastMatchingRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_findLastMatchingRecordingRequest_channel_in_acting_version(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_findLastMatchingRecordingRequest_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_findLastMatchingRecordingRequest_channel_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_findLastMatchingRecordingRequest_channel_length(
+    const struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_findLastMatchingRecordingRequest_channel(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_findLastMatchingRecordingRequest_get_channel(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec);
+    if (!aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest_string_view aeron_archive_client_findLastMatchingRecordingRequest_get_channel_as_string_view(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_findLastMatchingRecordingRequest_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_findLastMatchingRecordingRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_findLastMatchingRecordingRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_findLastMatchingRecordingRequest *aeron_archive_client_findLastMatchingRecordingRequest_put_channel(
+    struct aeron_archive_client_findLastMatchingRecordingRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_findLastMatchingRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_findLastMatchingRecordingRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/keepAliveRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/keepAliveRequest.h
@@ -1,0 +1,545 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_KEEPALIVEREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_KEEPALIVEREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_keepAliveRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_keepAliveRequest_meta_attribute
+{
+    aeron_archive_client_keepAliveRequest_meta_attribute_EPOCH,
+    aeron_archive_client_keepAliveRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_keepAliveRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_keepAliveRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_keepAliveRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_keepAliveRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_keepAliveRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_keepAliveRequest_sbe_position(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_keepAliveRequest_set_sbe_position(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_keepAliveRequest_sbe_position_ptr(
+    struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_reset(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_keepAliveRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_copy(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    const struct aeron_archive_client_keepAliveRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_keepAliveRequest_sbe_block_length(void)
+{
+    return (uint16_t)16;
+}
+
+#define AERON_ARCHIVE_CLIENT_KEEP_ALIVE_REQUEST_SBE_TEMPLATE_ID (uint16_t)61
+
+SBE_ONE_DEF uint16_t aeron_archive_client_keepAliveRequest_sbe_template_id(void)
+{
+    return (uint16_t)61;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_keepAliveRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_keepAliveRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_keepAliveRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_keepAliveRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_keepAliveRequest_offset(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_wrap_and_apply_header(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_keepAliveRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_keepAliveRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_keepAliveRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_keepAliveRequest_sbe_schema_version());
+
+    aeron_archive_client_keepAliveRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_keepAliveRequest_sbe_block_length(),
+        aeron_archive_client_keepAliveRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_wrap_for_encode(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_keepAliveRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_keepAliveRequest_sbe_block_length(),
+        aeron_archive_client_keepAliveRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_wrap_for_decode(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_keepAliveRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_sbe_rewind(
+    struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return aeron_archive_client_keepAliveRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_keepAliveRequest_encoded_length(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return aeron_archive_client_keepAliveRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_keepAliveRequest_buffer(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_keepAliveRequest_mut_buffer(
+    struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_keepAliveRequest_buffer_length(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_keepAliveRequest_acting_version(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_keepAliveRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_keepAliveRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_keepAliveRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_keepAliveRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_keepAliveRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_keepAliveRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_keepAliveRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_keepAliveRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_keepAliveRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_keepAliveRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_keepAliveRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_keepAliveRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_controlSessionId(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_set_controlSessionId(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_keepAliveRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_keepAliveRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_keepAliveRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_keepAliveRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_keepAliveRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_keepAliveRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_keepAliveRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_keepAliveRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_keepAliveRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_keepAliveRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_keepAliveRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_keepAliveRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_keepAliveRequest_correlationId(
+    const struct aeron_archive_client_keepAliveRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_keepAliveRequest *aeron_archive_client_keepAliveRequest_set_correlationId(
+    struct aeron_archive_client_keepAliveRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_LISTRECORDINGREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_LISTRECORDINGREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_listRecordingRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_listRecordingRequest_meta_attribute
+{
+    aeron_archive_client_listRecordingRequest_meta_attribute_EPOCH,
+    aeron_archive_client_listRecordingRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_listRecordingRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_listRecordingRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_listRecordingRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_listRecordingRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_listRecordingRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_sbe_position(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingRequest_set_sbe_position(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_listRecordingRequest_sbe_position_ptr(
+    struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_reset(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_listRecordingRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_copy(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    const struct aeron_archive_client_listRecordingRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_LIST_RECORDING_REQUEST_SBE_TEMPLATE_ID (uint16_t)10
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingRequest_sbe_template_id(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_listRecordingRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_offset(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_wrap_and_apply_header(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_listRecordingRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_listRecordingRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_listRecordingRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_listRecordingRequest_sbe_schema_version());
+
+    aeron_archive_client_listRecordingRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_listRecordingRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_wrap_for_encode(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_listRecordingRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_wrap_for_decode(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_sbe_rewind(
+    struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return aeron_archive_client_listRecordingRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_encoded_length(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return aeron_archive_client_listRecordingRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingRequest_buffer(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_listRecordingRequest_mut_buffer(
+    struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_buffer_length(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_acting_version(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_listRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_controlSessionId(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_set_controlSessionId(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_listRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_correlationId(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_set_correlationId(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_listRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingRequest_recordingId(
+    const struct aeron_archive_client_listRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingRequest *aeron_archive_client_listRecordingRequest_set_recordingId(
+    struct aeron_archive_client_listRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingSubscriptionsRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingSubscriptionsRequest.h
@@ -1,0 +1,1034 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_LISTRECORDINGSUBSCRIPTIONSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_LISTRECORDINGSUBSCRIPTIONSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_listRecordingSubscriptionsRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute
+{
+    aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH,
+    aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_listRecordingSubscriptionsRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_listRecordingSubscriptionsRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_listRecordingSubscriptionsRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position_ptr(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_reset(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_copy(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_LIST_RECORDING_SUBSCRIPTIONS_REQUEST_SBE_TEMPLATE_ID (uint16_t)17
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_sbe_template_id(void)
+{
+    return (uint16_t)17;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_listRecordingSubscriptionsRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_offset(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_wrap_and_apply_header(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_listRecordingSubscriptionsRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_listRecordingSubscriptionsRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_listRecordingSubscriptionsRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_listRecordingSubscriptionsRequest_sbe_schema_version());
+
+    aeron_archive_client_listRecordingSubscriptionsRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_listRecordingSubscriptionsRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingSubscriptionsRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_wrap_for_encode(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingSubscriptionsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_listRecordingSubscriptionsRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingSubscriptionsRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_wrap_for_decode(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingSubscriptionsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_sbe_rewind(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return aeron_archive_client_listRecordingSubscriptionsRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_encoded_length(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_buffer(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_listRecordingSubscriptionsRequest_mut_buffer(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_buffer_length(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_controlSessionId(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_set_controlSessionId(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingSubscriptionsRequest_correlationId(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_set_correlationId(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_meta_attribute(
+    const enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_in_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_pseudoIndex(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_set_pseudoIndex(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_meta_attribute(
+    const enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_in_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_encoding_offset(void)
+{
+    return 20;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_subscriptionCount(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 20, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_set_subscriptionCount(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 20, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId_meta_attribute(
+    const enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId_in_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_applyStreamId(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    enum aeron_archive_client_booleanType *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+
+    return aeron_archive_client_booleanType_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_set_applyStreamId(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const enum aeron_archive_client_booleanType value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_streamId_meta_attribute(
+    const enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_streamId_in_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingSubscriptionsRequest_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId_encoding_offset(void)
+{
+    return 28;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingSubscriptionsRequest_streamId(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 28, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_set_streamId(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 28, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_channel_meta_attribute(
+    const enum aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingSubscriptionsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingSubscriptionsRequest_channel_in_acting_version(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingSubscriptionsRequest_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingSubscriptionsRequest_channel_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_listRecordingSubscriptionsRequest_channel_length(
+    const struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingSubscriptionsRequest_channel(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(
+        codec, aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingSubscriptionsRequest_get_channel(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec);
+    if (!aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest_string_view aeron_archive_client_listRecordingSubscriptionsRequest_get_channel_as_string_view(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_listRecordingSubscriptionsRequest_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(
+        codec, aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_listRecordingSubscriptionsRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_listRecordingSubscriptionsRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingSubscriptionsRequest *aeron_archive_client_listRecordingSubscriptionsRequest_put_channel(
+    struct aeron_archive_client_listRecordingSubscriptionsRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_listRecordingSubscriptionsRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_listRecordingSubscriptionsRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingsForUriRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingsForUriRequest.h
@@ -1,0 +1,967 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_LISTRECORDINGSFORURIREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_LISTRECORDINGSFORURIREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_listRecordingsForUriRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_listRecordingsForUriRequest_meta_attribute
+{
+    aeron_archive_client_listRecordingsForUriRequest_meta_attribute_EPOCH,
+    aeron_archive_client_listRecordingsForUriRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_listRecordingsForUriRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_listRecordingsForUriRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_listRecordingsForUriRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_listRecordingsForUriRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_listRecordingsForUriRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_sbe_position(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_listRecordingsForUriRequest_sbe_position_ptr(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_reset(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_copy(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const struct aeron_archive_client_listRecordingsForUriRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_LIST_RECORDINGS_FOR_URI_REQUEST_SBE_TEMPLATE_ID (uint16_t)9
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_sbe_template_id(void)
+{
+    return (uint16_t)9;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_listRecordingsForUriRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_offset(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_wrap_and_apply_header(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_listRecordingsForUriRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_listRecordingsForUriRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_listRecordingsForUriRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_listRecordingsForUriRequest_sbe_schema_version());
+
+    aeron_archive_client_listRecordingsForUriRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_listRecordingsForUriRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingsForUriRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_wrap_for_encode(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingsForUriRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_listRecordingsForUriRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingsForUriRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_wrap_for_decode(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingsForUriRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_sbe_rewind(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return aeron_archive_client_listRecordingsForUriRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_encoded_length(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_buffer(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_listRecordingsForUriRequest_mut_buffer(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_buffer_length(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_acting_version(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_listRecordingsForUriRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsForUriRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsForUriRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_controlSessionId(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_set_controlSessionId(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_listRecordingsForUriRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsForUriRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsForUriRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_correlationId(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_set_correlationId(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_meta_attribute(
+    const enum aeron_archive_client_listRecordingsForUriRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_in_acting_version(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsForUriRequest_fromRecordingId(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_set_fromRecordingId(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_recordCount_meta_attribute(
+    const enum aeron_archive_client_listRecordingsForUriRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_recordCount_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_recordCount_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsForUriRequest_recordCount_in_acting_version(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsForUriRequest_recordCount_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_recordCount_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_recordCount_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_recordCount_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_recordCount_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_recordCount_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_recordCount(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_set_recordCount(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_streamId_meta_attribute(
+    const enum aeron_archive_client_listRecordingsForUriRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_streamId_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsForUriRequest_streamId_in_acting_version(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsForUriRequest_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_streamId_encoding_offset(void)
+{
+    return 28;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsForUriRequest_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsForUriRequest_streamId(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 28, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_set_streamId(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 28, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_channel_meta_attribute(
+    const enum aeron_archive_client_listRecordingsForUriRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsForUriRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsForUriRequest_channel_in_acting_version(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsForUriRequest_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsForUriRequest_channel_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_listRecordingsForUriRequest_channel_length(
+    const struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsForUriRequest_channel(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(
+        codec, aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsForUriRequest_get_channel(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec);
+    if (!aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest_string_view aeron_archive_client_listRecordingsForUriRequest_get_channel_as_string_view(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_listRecordingsForUriRequest_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(
+        codec, aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_listRecordingsForUriRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_listRecordingsForUriRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsForUriRequest *aeron_archive_client_listRecordingsForUriRequest_put_channel(
+    struct aeron_archive_client_listRecordingsForUriRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_listRecordingsForUriRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_listRecordingsForUriRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingsRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/listRecordingsRequest.h
@@ -1,0 +1,731 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_LISTRECORDINGSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_LISTRECORDINGSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_listRecordingsRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_listRecordingsRequest_meta_attribute
+{
+    aeron_archive_client_listRecordingsRequest_meta_attribute_EPOCH,
+    aeron_archive_client_listRecordingsRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_listRecordingsRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_listRecordingsRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_listRecordingsRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_listRecordingsRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_listRecordingsRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_sbe_position(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsRequest_set_sbe_position(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_listRecordingsRequest_sbe_position_ptr(
+    struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_reset(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_listRecordingsRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_copy(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    const struct aeron_archive_client_listRecordingsRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_sbe_block_length(void)
+{
+    return (uint16_t)28;
+}
+
+#define AERON_ARCHIVE_CLIENT_LIST_RECORDINGS_REQUEST_SBE_TEMPLATE_ID (uint16_t)8
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_sbe_template_id(void)
+{
+    return (uint16_t)8;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_listRecordingsRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_offset(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_wrap_and_apply_header(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_listRecordingsRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_listRecordingsRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_listRecordingsRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_listRecordingsRequest_sbe_schema_version());
+
+    aeron_archive_client_listRecordingsRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_listRecordingsRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingsRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_wrap_for_encode(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_listRecordingsRequest_sbe_block_length(),
+        aeron_archive_client_listRecordingsRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_wrap_for_decode(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_listRecordingsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_sbe_rewind(
+    struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return aeron_archive_client_listRecordingsRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_encoded_length(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return aeron_archive_client_listRecordingsRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsRequest_buffer(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_listRecordingsRequest_mut_buffer(
+    struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_buffer_length(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_acting_version(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_listRecordingsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_controlSessionId(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_set_controlSessionId(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_listRecordingsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_correlationId(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_set_correlationId(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsRequest_fromRecordingId_meta_attribute(
+    const enum aeron_archive_client_listRecordingsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_fromRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_fromRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsRequest_fromRecordingId_in_acting_version(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsRequest_fromRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_fromRecordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_fromRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_fromRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_fromRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_fromRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_listRecordingsRequest_fromRecordingId(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_set_fromRecordingId(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_listRecordingsRequest_recordCount_meta_attribute(
+    const enum aeron_archive_client_listRecordingsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_listRecordingsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_listRecordingsRequest_recordCount_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_listRecordingsRequest_recordCount_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_listRecordingsRequest_recordCount_in_acting_version(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_listRecordingsRequest_recordCount_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_recordCount_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsRequest_recordCount_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsRequest_recordCount_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsRequest_recordCount_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_listRecordingsRequest_recordCount_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_listRecordingsRequest_recordCount(
+    const struct aeron_archive_client_listRecordingsRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_listRecordingsRequest *aeron_archive_client_listRecordingsRequest_set_recordCount(
+    struct aeron_archive_client_listRecordingsRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/maxRecordedPositionRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/maxRecordedPositionRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_MAXRECORDEDPOSITIONREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_MAXRECORDEDPOSITIONREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_maxRecordedPositionRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_maxRecordedPositionRequest_meta_attribute
+{
+    aeron_archive_client_maxRecordedPositionRequest_meta_attribute_EPOCH,
+    aeron_archive_client_maxRecordedPositionRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_maxRecordedPositionRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_maxRecordedPositionRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_maxRecordedPositionRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_maxRecordedPositionRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_maxRecordedPositionRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_sbe_position(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_maxRecordedPositionRequest_set_sbe_position(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_maxRecordedPositionRequest_sbe_position_ptr(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_reset(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_maxRecordedPositionRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_copy(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    const struct aeron_archive_client_maxRecordedPositionRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_maxRecordedPositionRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_MAX_RECORDED_POSITION_REQUEST_SBE_TEMPLATE_ID (uint16_t)67
+
+SBE_ONE_DEF uint16_t aeron_archive_client_maxRecordedPositionRequest_sbe_template_id(void)
+{
+    return (uint16_t)67;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_maxRecordedPositionRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_maxRecordedPositionRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_maxRecordedPositionRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_maxRecordedPositionRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_offset(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_wrap_and_apply_header(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_maxRecordedPositionRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_maxRecordedPositionRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_maxRecordedPositionRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_maxRecordedPositionRequest_sbe_schema_version());
+
+    aeron_archive_client_maxRecordedPositionRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_maxRecordedPositionRequest_sbe_block_length(),
+        aeron_archive_client_maxRecordedPositionRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_wrap_for_encode(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_maxRecordedPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_maxRecordedPositionRequest_sbe_block_length(),
+        aeron_archive_client_maxRecordedPositionRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_wrap_for_decode(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_maxRecordedPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_sbe_rewind(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return aeron_archive_client_maxRecordedPositionRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_encoded_length(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return aeron_archive_client_maxRecordedPositionRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_maxRecordedPositionRequest_buffer(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_maxRecordedPositionRequest_mut_buffer(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_buffer_length(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_acting_version(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_maxRecordedPositionRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_maxRecordedPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_maxRecordedPositionRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_maxRecordedPositionRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_controlSessionId(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_set_controlSessionId(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_maxRecordedPositionRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_maxRecordedPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_maxRecordedPositionRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_maxRecordedPositionRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_maxRecordedPositionRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_maxRecordedPositionRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_maxRecordedPositionRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_correlationId(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_set_correlationId(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_maxRecordedPositionRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_maxRecordedPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_maxRecordedPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_maxRecordedPositionRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_maxRecordedPositionRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_maxRecordedPositionRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_maxRecordedPositionRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_maxRecordedPositionRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_maxRecordedPositionRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_maxRecordedPositionRequest_recordingId(
+    const struct aeron_archive_client_maxRecordedPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_maxRecordedPositionRequest *aeron_archive_client_maxRecordedPositionRequest_set_recordingId(
+    struct aeron_archive_client_maxRecordedPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/messageHeader.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/messageHeader.h
@@ -1,0 +1,590 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_MESSAGEHEADER_H_
+#define _AERON_ARCHIVE_CLIENT_MESSAGEHEADER_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_messageHeader
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_messageHeader_meta_attribute
+{
+    aeron_archive_client_messageHeader_meta_attribute_EPOCH,
+    aeron_archive_client_messageHeader_meta_attribute_TIME_UNIT,
+    aeron_archive_client_messageHeader_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_messageHeader_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_messageHeader_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_messageHeader_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_messageHeader_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF struct aeron_archive_client_messageHeader *aeron_archive_client_messageHeader_reset(
+    struct aeron_archive_client_messageHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_version)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT(((offset + 8) > buffer_length), false))
+    {
+        errno = E107;
+        return NULL;
+    }
+    codec->buffer = buffer;
+    codec->buffer_length = buffer_length;
+    codec->offset = offset;
+    codec->acting_version = acting_version;
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_messageHeader *aeron_archive_client_messageHeader_wrap(
+    struct aeron_archive_client_messageHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_messageHeader_reset(codec, buffer, offset, buffer_length, acting_version);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_messageHeader_encoded_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_messageHeader_offset(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_messageHeader_buffer(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_messageHeader_mut_buffer(
+    struct aeron_archive_client_messageHeader *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_messageHeader_buffer_length(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_messageHeader_blockLength_meta_attribute(
+    const enum aeron_archive_client_messageHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_messageHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_blockLength_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_messageHeader_blockLength_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_messageHeader_blockLength_in_acting_version(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_messageHeader_blockLength_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_blockLength_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_blockLength_null_value(void)
+{
+    return SBE_NULLVALUE_UINT16;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_blockLength_min_value(void)
+{
+    return (uint16_t)0;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_blockLength_max_value(void)
+{
+    return (uint16_t)65534;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_blockLength_encoding_length(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_blockLength(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+    uint16_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_16(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_messageHeader *aeron_archive_client_messageHeader_set_blockLength(
+    struct aeron_archive_client_messageHeader *const codec,
+    const uint16_t value)
+{
+    uint16_t val = SBE_LITTLE_ENDIAN_ENCODE_16(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_messageHeader_templateId_meta_attribute(
+    const enum aeron_archive_client_messageHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_messageHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_templateId_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_messageHeader_templateId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_messageHeader_templateId_in_acting_version(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_messageHeader_templateId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_templateId_encoding_offset(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_templateId_null_value(void)
+{
+    return SBE_NULLVALUE_UINT16;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_templateId_min_value(void)
+{
+    return (uint16_t)0;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_templateId_max_value(void)
+{
+    return (uint16_t)65534;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_templateId_encoding_length(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_templateId(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+    uint16_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 2, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_16(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_messageHeader *aeron_archive_client_messageHeader_set_templateId(
+    struct aeron_archive_client_messageHeader *const codec,
+    const uint16_t value)
+{
+    uint16_t val = SBE_LITTLE_ENDIAN_ENCODE_16(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 2, &val, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_messageHeader_schemaId_meta_attribute(
+    const enum aeron_archive_client_messageHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_messageHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_schemaId_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_messageHeader_schemaId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_messageHeader_schemaId_in_acting_version(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_messageHeader_schemaId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_schemaId_encoding_offset(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_schemaId_null_value(void)
+{
+    return SBE_NULLVALUE_UINT16;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_schemaId_min_value(void)
+{
+    return (uint16_t)0;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_schemaId_max_value(void)
+{
+    return (uint16_t)65534;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_schemaId_encoding_length(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_schemaId(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+    uint16_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 4, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_16(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_messageHeader *aeron_archive_client_messageHeader_set_schemaId(
+    struct aeron_archive_client_messageHeader *const codec,
+    const uint16_t value)
+{
+    uint16_t val = SBE_LITTLE_ENDIAN_ENCODE_16(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 4, &val, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_messageHeader_version_meta_attribute(
+    const enum aeron_archive_client_messageHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_messageHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_messageHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_version_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_messageHeader_version_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_messageHeader_version_in_acting_version(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_messageHeader_version_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_version_encoding_offset(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_version_null_value(void)
+{
+    return SBE_NULLVALUE_UINT16;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_version_min_value(void)
+{
+    return (uint16_t)0;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_version_max_value(void)
+{
+    return (uint16_t)65534;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_messageHeader_version_encoding_length(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_messageHeader_version(
+    const struct aeron_archive_client_messageHeader *const codec)
+{
+    uint16_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 6, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_16(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_messageHeader *aeron_archive_client_messageHeader_set_version(
+    struct aeron_archive_client_messageHeader *const codec,
+    const uint16_t value)
+{
+    uint16_t val = SBE_LITTLE_ENDIAN_ENCODE_16(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 6, &val, sizeof(uint16_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/migrateSegmentsRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/migrateSegmentsRequest.h
@@ -1,0 +1,731 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_MIGRATESEGMENTSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_MIGRATESEGMENTSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_migrateSegmentsRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_migrateSegmentsRequest_meta_attribute
+{
+    aeron_archive_client_migrateSegmentsRequest_meta_attribute_EPOCH,
+    aeron_archive_client_migrateSegmentsRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_migrateSegmentsRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_migrateSegmentsRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_migrateSegmentsRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_migrateSegmentsRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_migrateSegmentsRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_sbe_position(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_migrateSegmentsRequest_set_sbe_position(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_migrateSegmentsRequest_sbe_position_ptr(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_reset(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_migrateSegmentsRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_copy(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    const struct aeron_archive_client_migrateSegmentsRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_MIGRATE_SEGMENTS_REQUEST_SBE_TEMPLATE_ID (uint16_t)57
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_sbe_template_id(void)
+{
+    return (uint16_t)57;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_migrateSegmentsRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_migrateSegmentsRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_offset(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_wrap_and_apply_header(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_migrateSegmentsRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_migrateSegmentsRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_migrateSegmentsRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_migrateSegmentsRequest_sbe_schema_version());
+
+    aeron_archive_client_migrateSegmentsRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_migrateSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_migrateSegmentsRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_wrap_for_encode(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_migrateSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_migrateSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_migrateSegmentsRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_wrap_for_decode(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_migrateSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_sbe_rewind(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return aeron_archive_client_migrateSegmentsRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_encoded_length(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return aeron_archive_client_migrateSegmentsRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_migrateSegmentsRequest_buffer(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_migrateSegmentsRequest_mut_buffer(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_buffer_length(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_acting_version(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_migrateSegmentsRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_migrateSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_migrateSegmentsRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_migrateSegmentsRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_controlSessionId(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_set_controlSessionId(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_migrateSegmentsRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_migrateSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_migrateSegmentsRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_migrateSegmentsRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_correlationId(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_set_correlationId(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_migrateSegmentsRequest_srcRecordingId_meta_attribute(
+    const enum aeron_archive_client_migrateSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_migrateSegmentsRequest_srcRecordingId_in_acting_version(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_migrateSegmentsRequest_srcRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_srcRecordingId(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_set_srcRecordingId(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_migrateSegmentsRequest_dstRecordingId_meta_attribute(
+    const enum aeron_archive_client_migrateSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_migrateSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_migrateSegmentsRequest_dstRecordingId_in_acting_version(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_migrateSegmentsRequest_dstRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_migrateSegmentsRequest_dstRecordingId(
+    const struct aeron_archive_client_migrateSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_migrateSegmentsRequest *aeron_archive_client_migrateSegmentsRequest_set_dstRecordingId(
+    struct aeron_archive_client_migrateSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/purgeRecordingRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/purgeRecordingRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_PURGERECORDINGREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_PURGERECORDINGREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_purgeRecordingRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_purgeRecordingRequest_meta_attribute
+{
+    aeron_archive_client_purgeRecordingRequest_meta_attribute_EPOCH,
+    aeron_archive_client_purgeRecordingRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_purgeRecordingRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_purgeRecordingRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_purgeRecordingRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_purgeRecordingRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_purgeRecordingRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_sbe_position(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeRecordingRequest_set_sbe_position(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_purgeRecordingRequest_sbe_position_ptr(
+    struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_reset(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_purgeRecordingRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_copy(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    const struct aeron_archive_client_purgeRecordingRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeRecordingRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_PURGE_RECORDING_REQUEST_SBE_TEMPLATE_ID (uint16_t)104
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeRecordingRequest_sbe_template_id(void)
+{
+    return (uint16_t)104;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeRecordingRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeRecordingRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_purgeRecordingRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeRecordingRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_offset(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_wrap_and_apply_header(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_purgeRecordingRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_purgeRecordingRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_purgeRecordingRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_purgeRecordingRequest_sbe_schema_version());
+
+    aeron_archive_client_purgeRecordingRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_purgeRecordingRequest_sbe_block_length(),
+        aeron_archive_client_purgeRecordingRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_wrap_for_encode(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_purgeRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_purgeRecordingRequest_sbe_block_length(),
+        aeron_archive_client_purgeRecordingRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_wrap_for_decode(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_purgeRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_sbe_rewind(
+    struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return aeron_archive_client_purgeRecordingRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_encoded_length(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return aeron_archive_client_purgeRecordingRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeRecordingRequest_buffer(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_purgeRecordingRequest_mut_buffer(
+    struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_buffer_length(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_acting_version(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeRecordingRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_purgeRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeRecordingRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeRecordingRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_purgeRecordingRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeRecordingRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeRecordingRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_controlSessionId(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_set_controlSessionId(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeRecordingRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_purgeRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeRecordingRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeRecordingRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_purgeRecordingRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeRecordingRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeRecordingRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_correlationId(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_set_correlationId(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeRecordingRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_purgeRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_purgeRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeRecordingRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeRecordingRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeRecordingRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_purgeRecordingRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeRecordingRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeRecordingRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeRecordingRequest_recordingId(
+    const struct aeron_archive_client_purgeRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeRecordingRequest *aeron_archive_client_purgeRecordingRequest_set_recordingId(
+    struct aeron_archive_client_purgeRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/purgeSegmentsRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/purgeSegmentsRequest.h
@@ -1,0 +1,731 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_PURGESEGMENTSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_PURGESEGMENTSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_purgeSegmentsRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_purgeSegmentsRequest_meta_attribute
+{
+    aeron_archive_client_purgeSegmentsRequest_meta_attribute_EPOCH,
+    aeron_archive_client_purgeSegmentsRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_purgeSegmentsRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_purgeSegmentsRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_purgeSegmentsRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_purgeSegmentsRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_purgeSegmentsRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_sbe_position(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeSegmentsRequest_set_sbe_position(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_purgeSegmentsRequest_sbe_position_ptr(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_reset(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_purgeSegmentsRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_copy(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    const struct aeron_archive_client_purgeSegmentsRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_PURGE_SEGMENTS_REQUEST_SBE_TEMPLATE_ID (uint16_t)55
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_sbe_template_id(void)
+{
+    return (uint16_t)55;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_purgeSegmentsRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeSegmentsRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_offset(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_wrap_and_apply_header(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_purgeSegmentsRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_purgeSegmentsRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_purgeSegmentsRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_purgeSegmentsRequest_sbe_schema_version());
+
+    aeron_archive_client_purgeSegmentsRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_purgeSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_purgeSegmentsRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_wrap_for_encode(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_purgeSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_purgeSegmentsRequest_sbe_block_length(),
+        aeron_archive_client_purgeSegmentsRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_wrap_for_decode(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_purgeSegmentsRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_sbe_rewind(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return aeron_archive_client_purgeSegmentsRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_encoded_length(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return aeron_archive_client_purgeSegmentsRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeSegmentsRequest_buffer(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_purgeSegmentsRequest_mut_buffer(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_buffer_length(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_acting_version(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeSegmentsRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_purgeSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeSegmentsRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_purgeSegmentsRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_controlSessionId(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_set_controlSessionId(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeSegmentsRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_purgeSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeSegmentsRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_purgeSegmentsRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_correlationId(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_set_correlationId(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeSegmentsRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_purgeSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeSegmentsRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_purgeSegmentsRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_recordingId(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_set_recordingId(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_purgeSegmentsRequest_newStartPosition_meta_attribute(
+    const enum aeron_archive_client_purgeSegmentsRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_purgeSegmentsRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_purgeSegmentsRequest_newStartPosition_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_purgeSegmentsRequest_newStartPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_purgeSegmentsRequest_newStartPosition_in_acting_version(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_purgeSegmentsRequest_newStartPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_newStartPosition_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_newStartPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_newStartPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_newStartPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_purgeSegmentsRequest_newStartPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_purgeSegmentsRequest_newStartPosition(
+    const struct aeron_archive_client_purgeSegmentsRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_purgeSegmentsRequest *aeron_archive_client_purgeSegmentsRequest_set_newStartPosition(
+    struct aeron_archive_client_purgeSegmentsRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingDescriptor.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingDescriptor.h
@@ -1,0 +1,1997 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGDESCRIPTOR_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGDESCRIPTOR_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingDescriptor
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingDescriptor_meta_attribute
+{
+    aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH,
+    aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingDescriptor_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingDescriptor_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingDescriptor_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_sbe_position(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_set_sbe_position(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingDescriptor_sbe_position_ptr(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_reset(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_copy(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const struct aeron_archive_client_recordingDescriptor *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_sbe_block_length(void)
+{
+    return (uint16_t)80;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_DESCRIPTOR_SBE_TEMPLATE_ID (uint16_t)22
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_sbe_template_id(void)
+{
+    return (uint16_t)22;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingDescriptor_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_offset(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_wrap_and_apply_header(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingDescriptor_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingDescriptor_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingDescriptor_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingDescriptor_sbe_schema_version());
+
+    aeron_archive_client_recordingDescriptor_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingDescriptor_sbe_block_length(),
+        aeron_archive_client_recordingDescriptor_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_wrap_for_encode(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingDescriptor_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingDescriptor_sbe_block_length(),
+        aeron_archive_client_recordingDescriptor_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_wrap_for_decode(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingDescriptor_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_sbe_rewind(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return aeron_archive_client_recordingDescriptor_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_encoded_length(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return aeron_archive_client_recordingDescriptor_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_buffer(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingDescriptor_mut_buffer(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_buffer_length(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_controlSessionId(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_controlSessionId(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_correlationId_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_correlationId_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_correlationId(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_correlationId(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_recordingId_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_recordingId_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_recordingId(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_recordingId(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_startTimestamp_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_startTimestamp_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_startTimestamp_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_startTimestamp_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_startTimestamp_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_startTimestamp_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startTimestamp_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startTimestamp_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startTimestamp_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_startTimestamp_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startTimestamp(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_startTimestamp(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_stopTimestamp_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_stopTimestamp_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_stopTimestamp_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_stopTimestamp_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_stopTimestamp_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_stopTimestamp_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopTimestamp_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopTimestamp_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopTimestamp_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_stopTimestamp_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopTimestamp(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_stopTimestamp(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_startPosition_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_startPosition_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_startPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_startPosition_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_startPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_startPosition_encoding_offset(void)
+{
+    return 40;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_startPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_startPosition(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 40, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_startPosition(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 40, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_stopPosition_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_stopPosition_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_stopPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_stopPosition_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_stopPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_stopPosition_encoding_offset(void)
+{
+    return 48;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_stopPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingDescriptor_stopPosition(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 48, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_stopPosition(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 48, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_initialTermId_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_initialTermId_id(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_initialTermId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_initialTermId_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_initialTermId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_initialTermId_encoding_offset(void)
+{
+    return 56;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_initialTermId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_initialTermId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_initialTermId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_initialTermId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_initialTermId(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 56, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_initialTermId(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 56, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_segmentFileLength_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_segmentFileLength_id(void)
+{
+    return 9;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_segmentFileLength_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_segmentFileLength_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_segmentFileLength_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_segmentFileLength_encoding_offset(void)
+{
+    return 60;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_segmentFileLength_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_segmentFileLength_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_segmentFileLength_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_segmentFileLength_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_segmentFileLength(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 60, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_segmentFileLength(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 60, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_termBufferLength_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_termBufferLength_id(void)
+{
+    return 10;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_termBufferLength_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_termBufferLength_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_termBufferLength_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_termBufferLength_encoding_offset(void)
+{
+    return 64;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_termBufferLength_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_termBufferLength_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_termBufferLength_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_termBufferLength_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_termBufferLength(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 64, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_termBufferLength(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 64, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_mtuLength_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_mtuLength_id(void)
+{
+    return 11;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_mtuLength_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_mtuLength_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_mtuLength_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_mtuLength_encoding_offset(void)
+{
+    return 68;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_mtuLength_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_mtuLength_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_mtuLength_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_mtuLength_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_mtuLength(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 68, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_mtuLength(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 68, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_sessionId_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_sessionId_id(void)
+{
+    return 12;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_sessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_sessionId_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_sessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_sessionId_encoding_offset(void)
+{
+    return 72;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_sessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_sessionId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_sessionId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_sessionId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_sessionId(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 72, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_sessionId(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 72, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_streamId_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_streamId_id(void)
+{
+    return 13;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_streamId_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_streamId_encoding_offset(void)
+{
+    return 76;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptor_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptor_streamId(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 76, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_set_streamId(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 76, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_strippedChannel_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_strippedChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_strippedChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_strippedChannel_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_strippedChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_strippedChannel_id(void)
+{
+    return 14;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_strippedChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_recordingDescriptor_strippedChannel_length(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_strippedChannel(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_get_strippedChannel(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor_string_view aeron_archive_client_recordingDescriptor_get_strippedChannel_as_string_view(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_recordingDescriptor_strippedChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4;
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_recordingDescriptor_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_recordingDescriptor_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_put_strippedChannel(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_originalChannel_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_originalChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_originalChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_originalChannel_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_originalChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_originalChannel_id(void)
+{
+    return 15;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_originalChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_recordingDescriptor_originalChannel_length(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_originalChannel(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_get_originalChannel(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor_string_view aeron_archive_client_recordingDescriptor_get_originalChannel_as_string_view(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_recordingDescriptor_originalChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4;
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_recordingDescriptor_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_recordingDescriptor_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_put_originalChannel(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_sourceIdentity_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_sourceIdentity_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_sourceIdentity_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptor_sourceIdentity_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptor_sourceIdentity_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptor_sourceIdentity_id(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_sourceIdentity_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_recordingDescriptor_sourceIdentity_length(
+    const struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptor_sourceIdentity(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptor_get_sourceIdentity(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor_string_view aeron_archive_client_recordingDescriptor_get_sourceIdentity_as_string_view(
+    struct aeron_archive_client_recordingDescriptor *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_recordingDescriptor_sourceIdentity_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4;
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingDescriptor_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_recordingDescriptor_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_recordingDescriptor_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptor *aeron_archive_client_recordingDescriptor_put_sourceIdentity(
+    struct aeron_archive_client_recordingDescriptor *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_recordingDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingDescriptor_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingDescriptorHeader.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingDescriptorHeader.h
@@ -1,0 +1,705 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGDESCRIPTORHEADER_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGDESCRIPTORHEADER_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingDescriptorHeader
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingDescriptorHeader_meta_attribute
+{
+    aeron_archive_client_recordingDescriptorHeader_meta_attribute_EPOCH,
+    aeron_archive_client_recordingDescriptorHeader_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingDescriptorHeader_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingDescriptorHeader_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingDescriptorHeader_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingDescriptorHeader_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingDescriptorHeader_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_sbe_position(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptorHeader_set_sbe_position(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingDescriptorHeader_sbe_position_ptr(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_reset(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingDescriptorHeader_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_copy(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    const struct aeron_archive_client_recordingDescriptorHeader *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_DESCRIPTOR_HEADER_SBE_TEMPLATE_ID (uint16_t)21
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_sbe_template_id(void)
+{
+    return (uint16_t)21;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingDescriptorHeader_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptorHeader_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_offset(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_wrap_and_apply_header(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingDescriptorHeader_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingDescriptorHeader_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingDescriptorHeader_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingDescriptorHeader_sbe_schema_version());
+
+    aeron_archive_client_recordingDescriptorHeader_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingDescriptorHeader_sbe_block_length(),
+        aeron_archive_client_recordingDescriptorHeader_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_wrap_for_encode(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingDescriptorHeader_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingDescriptorHeader_sbe_block_length(),
+        aeron_archive_client_recordingDescriptorHeader_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_wrap_for_decode(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingDescriptorHeader_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_sbe_rewind(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return aeron_archive_client_recordingDescriptorHeader_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_encoded_length(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return aeron_archive_client_recordingDescriptorHeader_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptorHeader_buffer(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingDescriptorHeader_mut_buffer(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_buffer_length(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_acting_version(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptorHeader_length_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptorHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_length_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_length_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptorHeader_length_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptorHeader_length_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_length_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_length_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_length_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_length_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_length_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_length(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_set_length(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptorHeader_state_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptorHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_state_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_state_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptorHeader_state_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptorHeader_state_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_state_encoding_offset(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_state_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptorHeader_state(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    enum aeron_archive_client_recordingState *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 4, sizeof(int32_t));
+
+    return aeron_archive_client_recordingState_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_set_state(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    const enum aeron_archive_client_recordingState value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 4, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptorHeader_checksum_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptorHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_checksum_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_checksum_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptorHeader_checksum_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptorHeader_checksum_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_checksum_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_checksum_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_checksum_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_checksum_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_checksum_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingDescriptorHeader_checksum(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_set_checksum(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingDescriptorHeader_reserved_meta_attribute(
+    const enum aeron_archive_client_recordingDescriptorHeader_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingDescriptorHeader_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingDescriptorHeader_reserved_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingDescriptorHeader_reserved_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingDescriptorHeader_reserved_in_acting_version(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingDescriptorHeader_reserved_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_reserved_encoding_offset(void)
+{
+    return 31;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_recordingDescriptorHeader_reserved_null_value(void)
+{
+    return SBE_NULLVALUE_INT8;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_recordingDescriptorHeader_reserved_min_value(void)
+{
+    return (int8_t)-127;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_recordingDescriptorHeader_reserved_max_value(void)
+{
+    return (int8_t)127;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingDescriptorHeader_reserved_encoding_length(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF int8_t aeron_archive_client_recordingDescriptorHeader_reserved(
+    const struct aeron_archive_client_recordingDescriptorHeader *const codec)
+{
+    int8_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 31, sizeof(int8_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return (val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingDescriptorHeader *aeron_archive_client_recordingDescriptorHeader_set_reserved(
+    struct aeron_archive_client_recordingDescriptorHeader *const codec,
+    const int8_t value)
+{
+    int8_t val = (value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 31, &val, sizeof(int8_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingPositionRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingPositionRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGPOSITIONREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGPOSITIONREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingPositionRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingPositionRequest_meta_attribute
+{
+    aeron_archive_client_recordingPositionRequest_meta_attribute_EPOCH,
+    aeron_archive_client_recordingPositionRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingPositionRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingPositionRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingPositionRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingPositionRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingPositionRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_sbe_position(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingPositionRequest_set_sbe_position(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingPositionRequest_sbe_position_ptr(
+    struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_reset(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingPositionRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_copy(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    const struct aeron_archive_client_recordingPositionRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingPositionRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_POSITION_REQUEST_SBE_TEMPLATE_ID (uint16_t)12
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingPositionRequest_sbe_template_id(void)
+{
+    return (uint16_t)12;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingPositionRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingPositionRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingPositionRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingPositionRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_offset(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_wrap_and_apply_header(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingPositionRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingPositionRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingPositionRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingPositionRequest_sbe_schema_version());
+
+    aeron_archive_client_recordingPositionRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingPositionRequest_sbe_block_length(),
+        aeron_archive_client_recordingPositionRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_wrap_for_encode(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingPositionRequest_sbe_block_length(),
+        aeron_archive_client_recordingPositionRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_wrap_for_decode(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_sbe_rewind(
+    struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return aeron_archive_client_recordingPositionRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_encoded_length(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return aeron_archive_client_recordingPositionRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingPositionRequest_buffer(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingPositionRequest_mut_buffer(
+    struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_buffer_length(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_acting_version(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingPositionRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_recordingPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingPositionRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingPositionRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingPositionRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingPositionRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingPositionRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_controlSessionId(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_set_controlSessionId(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingPositionRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_recordingPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingPositionRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingPositionRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingPositionRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingPositionRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingPositionRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_correlationId(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_set_correlationId(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingPositionRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_recordingPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingPositionRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingPositionRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingPositionRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingPositionRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingPositionRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingPositionRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingPositionRequest_recordingId(
+    const struct aeron_archive_client_recordingPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingPositionRequest *aeron_archive_client_recordingPositionRequest_set_recordingId(
+    struct aeron_archive_client_recordingPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingProgress.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingProgress.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGPROGRESS_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGPROGRESS_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingProgress
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingProgress_meta_attribute
+{
+    aeron_archive_client_recordingProgress_meta_attribute_EPOCH,
+    aeron_archive_client_recordingProgress_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingProgress_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingProgress_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingProgress_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingProgress_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingProgress_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_sbe_position(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingProgress_set_sbe_position(
+    struct aeron_archive_client_recordingProgress *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingProgress_sbe_position_ptr(
+    struct aeron_archive_client_recordingProgress *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_reset(
+    struct aeron_archive_client_recordingProgress *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingProgress_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_copy(
+    struct aeron_archive_client_recordingProgress *const codec,
+    const struct aeron_archive_client_recordingProgress *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingProgress_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_PROGRESS_SBE_TEMPLATE_ID (uint16_t)102
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingProgress_sbe_template_id(void)
+{
+    return (uint16_t)102;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingProgress_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingProgress_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingProgress_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingProgress_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_offset(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_wrap_and_apply_header(
+    struct aeron_archive_client_recordingProgress *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingProgress_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingProgress_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingProgress_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingProgress_sbe_schema_version());
+
+    aeron_archive_client_recordingProgress_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingProgress_sbe_block_length(),
+        aeron_archive_client_recordingProgress_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_wrap_for_encode(
+    struct aeron_archive_client_recordingProgress *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingProgress_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingProgress_sbe_block_length(),
+        aeron_archive_client_recordingProgress_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_wrap_for_decode(
+    struct aeron_archive_client_recordingProgress *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingProgress_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_sbe_rewind(
+    struct aeron_archive_client_recordingProgress *const codec)
+{
+    return aeron_archive_client_recordingProgress_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_encoded_length(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    return aeron_archive_client_recordingProgress_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingProgress_buffer(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingProgress_mut_buffer(
+    struct aeron_archive_client_recordingProgress *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_buffer_length(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_acting_version(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingProgress_recordingId_meta_attribute(
+    const enum aeron_archive_client_recordingProgress_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingProgress_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingProgress_recordingId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingProgress_recordingId_in_acting_version(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingProgress_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingProgress_recordingId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingProgress_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_recordingId(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_set_recordingId(
+    struct aeron_archive_client_recordingProgress *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingProgress_startPosition_meta_attribute(
+    const enum aeron_archive_client_recordingProgress_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingProgress_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingProgress_startPosition_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_startPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingProgress_startPosition_in_acting_version(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingProgress_startPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingProgress_startPosition_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_startPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_startPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_startPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingProgress_startPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_startPosition(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_set_startPosition(
+    struct aeron_archive_client_recordingProgress *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingProgress_position_meta_attribute(
+    const enum aeron_archive_client_recordingProgress_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingProgress_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingProgress_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingProgress_position_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingProgress_position_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingProgress_position_in_acting_version(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingProgress_position_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingProgress_position_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_position_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_position_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_position_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingProgress_position_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingProgress_position(
+    const struct aeron_archive_client_recordingProgress *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingProgress *aeron_archive_client_recordingProgress_set_position(
+    struct aeron_archive_client_recordingProgress *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingSignal.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingSignal.h
@@ -1,0 +1,167 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGSIGNAL_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGSIGNAL_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+enum aeron_archive_client_recordingSignal
+{
+    aeron_archive_client_recordingSignal_START = INT32_C(0),
+    aeron_archive_client_recordingSignal_STOP = INT32_C(1),
+    aeron_archive_client_recordingSignal_EXTEND = INT32_C(2),
+    aeron_archive_client_recordingSignal_REPLICATE = INT32_C(3),
+    aeron_archive_client_recordingSignal_MERGE = INT32_C(4),
+    aeron_archive_client_recordingSignal_SYNC = INT32_C(5),
+    aeron_archive_client_recordingSignal_DELETE = INT32_C(6),
+    aeron_archive_client_recordingSignal_REPLICATE_END = INT32_C(7),
+    aeron_archive_client_recordingSignal_NULL_VALUE = INT32_MIN
+};
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignal_get(
+    const int32_t value,
+    enum aeron_archive_client_recordingSignal *const out)
+{
+    switch (value)
+    {
+        case INT32_C(0):
+             *out = aeron_archive_client_recordingSignal_START;
+             return true;
+        case INT32_C(1):
+             *out = aeron_archive_client_recordingSignal_STOP;
+             return true;
+        case INT32_C(2):
+             *out = aeron_archive_client_recordingSignal_EXTEND;
+             return true;
+        case INT32_C(3):
+             *out = aeron_archive_client_recordingSignal_REPLICATE;
+             return true;
+        case INT32_C(4):
+             *out = aeron_archive_client_recordingSignal_MERGE;
+             return true;
+        case INT32_C(5):
+             *out = aeron_archive_client_recordingSignal_SYNC;
+             return true;
+        case INT32_C(6):
+             *out = aeron_archive_client_recordingSignal_DELETE;
+             return true;
+        case INT32_C(7):
+             *out = aeron_archive_client_recordingSignal_REPLICATE_END;
+             return true;
+        case INT32_MIN:
+             *out = aeron_archive_client_recordingSignal_NULL_VALUE;
+             return true;
+    }
+
+    errno = E103;
+    return false;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingSignalEvent.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingSignalEvent.h
@@ -1,0 +1,891 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGSIGNALEVENT_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGSIGNALEVENT_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingSignalEvent
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingSignalEvent_meta_attribute
+{
+    aeron_archive_client_recordingSignalEvent_meta_attribute_EPOCH,
+    aeron_archive_client_recordingSignalEvent_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingSignalEvent_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingSignalEvent_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingSignalEvent_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingSignalEvent_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingSignalEvent_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_sbe_position(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_set_sbe_position(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingSignalEvent_sbe_position_ptr(
+    struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_reset(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingSignalEvent_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_copy(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const struct aeron_archive_client_recordingSignalEvent *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_sbe_block_length(void)
+{
+    return (uint16_t)44;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_SIGNAL_EVENT_SBE_TEMPLATE_ID (uint16_t)24
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_sbe_template_id(void)
+{
+    return (uint16_t)24;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingSignalEvent_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_offset(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_wrap_and_apply_header(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingSignalEvent_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingSignalEvent_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingSignalEvent_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingSignalEvent_sbe_schema_version());
+
+    aeron_archive_client_recordingSignalEvent_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingSignalEvent_sbe_block_length(),
+        aeron_archive_client_recordingSignalEvent_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_wrap_for_encode(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingSignalEvent_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingSignalEvent_sbe_block_length(),
+        aeron_archive_client_recordingSignalEvent_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_wrap_for_decode(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingSignalEvent_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_sbe_rewind(
+    struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return aeron_archive_client_recordingSignalEvent_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_encoded_length(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return aeron_archive_client_recordingSignalEvent_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_buffer(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingSignalEvent_mut_buffer(
+    struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_buffer_length(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_acting_version(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_recordingSignalEvent_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSignalEvent_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_controlSessionId(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_set_controlSessionId(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_correlationId_meta_attribute(
+    const enum aeron_archive_client_recordingSignalEvent_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_correlationId_in_acting_version(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSignalEvent_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_correlationId(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_set_correlationId(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_recordingId_meta_attribute(
+    const enum aeron_archive_client_recordingSignalEvent_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_recordingId_in_acting_version(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSignalEvent_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_recordingId(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_set_recordingId(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_subscriptionId_meta_attribute(
+    const enum aeron_archive_client_recordingSignalEvent_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_subscriptionId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_subscriptionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_subscriptionId_in_acting_version(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSignalEvent_subscriptionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_subscriptionId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_subscriptionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_subscriptionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_subscriptionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_subscriptionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_subscriptionId(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_set_subscriptionId(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_position_meta_attribute(
+    const enum aeron_archive_client_recordingSignalEvent_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_position_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_position_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_position_in_acting_version(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSignalEvent_position_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_position_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_position_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_position_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_position_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_position_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSignalEvent_position(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_set_position(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSignalEvent_signal_meta_attribute(
+    const enum aeron_archive_client_recordingSignalEvent_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSignalEvent_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSignalEvent_signal_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSignalEvent_signal_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_signal_in_acting_version(
+    const struct aeron_archive_client_recordingSignalEvent *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSignalEvent_signal_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_signal_encoding_offset(void)
+{
+    return 40;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSignalEvent_signal_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSignalEvent_signal(
+    const struct aeron_archive_client_recordingSignalEvent *const codec,
+    enum aeron_archive_client_recordingSignal *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 40, sizeof(int32_t));
+
+    return aeron_archive_client_recordingSignal_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSignalEvent *aeron_archive_client_recordingSignalEvent_set_signal(
+    struct aeron_archive_client_recordingSignalEvent *const codec,
+    const enum aeron_archive_client_recordingSignal value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 40, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingStarted.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingStarted.h
@@ -1,0 +1,1017 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGSTARTED_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGSTARTED_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingStarted
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingStarted_meta_attribute
+{
+    aeron_archive_client_recordingStarted_meta_attribute_EPOCH,
+    aeron_archive_client_recordingStarted_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingStarted_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingStarted_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingStarted_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingStarted_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingStarted_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_sbe_position(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStarted_set_sbe_position(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingStarted_sbe_position_ptr(
+    struct aeron_archive_client_recordingStarted *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_reset(
+    struct aeron_archive_client_recordingStarted *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_copy(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const struct aeron_archive_client_recordingStarted *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_STARTED_SBE_TEMPLATE_ID (uint16_t)101
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_sbe_template_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingStarted_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_offset(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_wrap_and_apply_header(
+    struct aeron_archive_client_recordingStarted *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingStarted_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingStarted_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingStarted_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingStarted_sbe_schema_version());
+
+    aeron_archive_client_recordingStarted_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingStarted_sbe_block_length(),
+        aeron_archive_client_recordingStarted_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_wrap_for_encode(
+    struct aeron_archive_client_recordingStarted *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingStarted_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingStarted_sbe_block_length(),
+        aeron_archive_client_recordingStarted_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_wrap_for_decode(
+    struct aeron_archive_client_recordingStarted *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingStarted_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_sbe_rewind(
+    struct aeron_archive_client_recordingStarted *const codec)
+{
+    return aeron_archive_client_recordingStarted_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_encoded_length(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    return aeron_archive_client_recordingStarted_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_buffer(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingStarted_mut_buffer(
+    struct aeron_archive_client_recordingStarted *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_buffer_length(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_acting_version(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_recordingId_meta_attribute(
+    const enum aeron_archive_client_recordingStarted_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStarted_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_recordingId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStarted_recordingId_in_acting_version(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStarted_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_recordingId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_recordingId(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_set_recordingId(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_startPosition_meta_attribute(
+    const enum aeron_archive_client_recordingStarted_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStarted_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_startPosition_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_startPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStarted_startPosition_in_acting_version(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStarted_startPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_startPosition_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_startPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_startPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_startPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_startPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStarted_startPosition(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_set_startPosition(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_sessionId_meta_attribute(
+    const enum aeron_archive_client_recordingStarted_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStarted_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_sessionId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_sessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStarted_sessionId_in_acting_version(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStarted_sessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_sessionId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_sessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_sessionId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_sessionId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_sessionId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_sessionId(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_set_sessionId(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_streamId_meta_attribute(
+    const enum aeron_archive_client_recordingStarted_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStarted_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_streamId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStarted_streamId_in_acting_version(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStarted_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_streamId_encoding_offset(void)
+{
+    return 20;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStarted_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingStarted_streamId(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 20, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_set_streamId(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 20, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_channel_meta_attribute(
+    const enum aeron_archive_client_recordingStarted_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStarted_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStarted_channel_in_acting_version(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStarted_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_channel_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_recordingStarted_channel_length(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_channel(
+    struct aeron_archive_client_recordingStarted *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(
+        codec, aeron_archive_client_recordingStarted_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_get_channel(
+    struct aeron_archive_client_recordingStarted *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingStarted_sbe_position(codec);
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_recordingStarted_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted_string_view aeron_archive_client_recordingStarted_get_channel_as_string_view(
+    struct aeron_archive_client_recordingStarted *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_recordingStarted_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec) + 4;
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(
+        codec, aeron_archive_client_recordingStarted_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_recordingStarted_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_recordingStarted_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_put_channel(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingStarted_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_recordingStarted_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_sourceIdentity_meta_attribute(
+    const enum aeron_archive_client_recordingStarted_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStarted_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStarted_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_sourceIdentity_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_sourceIdentity_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStarted_sourceIdentity_in_acting_version(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStarted_sourceIdentity_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStarted_sourceIdentity_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_sourceIdentity_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_recordingStarted_sourceIdentity_length(
+    const struct aeron_archive_client_recordingStarted *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStarted_sourceIdentity(
+    struct aeron_archive_client_recordingStarted *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(
+        codec, aeron_archive_client_recordingStarted_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStarted_get_sourceIdentity(
+    struct aeron_archive_client_recordingStarted *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingStarted_sbe_position(codec);
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_recordingStarted_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted_string_view aeron_archive_client_recordingStarted_get_sourceIdentity_as_string_view(
+    struct aeron_archive_client_recordingStarted *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_recordingStarted_sourceIdentity_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_recordingStarted_sbe_position(codec) + 4;
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(
+        codec, aeron_archive_client_recordingStarted_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_recordingStarted_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_recordingStarted_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStarted *aeron_archive_client_recordingStarted_put_sourceIdentity(
+    struct aeron_archive_client_recordingStarted *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingStarted_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_recordingStarted_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingStarted_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingState.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingState.h
@@ -1,0 +1,147 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGSTATE_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGSTATE_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+enum aeron_archive_client_recordingState
+{
+    aeron_archive_client_recordingState_INVALID = INT32_C(0),
+    aeron_archive_client_recordingState_VALID = INT32_C(1),
+    aeron_archive_client_recordingState_DELETED = INT32_C(2),
+    aeron_archive_client_recordingState_NULL_VALUE = INT32_MIN
+};
+
+SBE_ONE_DEF bool aeron_archive_client_recordingState_get(
+    const int32_t value,
+    enum aeron_archive_client_recordingState *const out)
+{
+    switch (value)
+    {
+        case INT32_C(0):
+             *out = aeron_archive_client_recordingState_INVALID;
+             return true;
+        case INT32_C(1):
+             *out = aeron_archive_client_recordingState_VALID;
+             return true;
+        case INT32_C(2):
+             *out = aeron_archive_client_recordingState_DELETED;
+             return true;
+        case INT32_MIN:
+             *out = aeron_archive_client_recordingState_NULL_VALUE;
+             return true;
+    }
+
+    errno = E103;
+    return false;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingStopped.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingStopped.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGSTOPPED_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGSTOPPED_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingStopped
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingStopped_meta_attribute
+{
+    aeron_archive_client_recordingStopped_meta_attribute_EPOCH,
+    aeron_archive_client_recordingStopped_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingStopped_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingStopped_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingStopped_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingStopped_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingStopped_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_sbe_position(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStopped_set_sbe_position(
+    struct aeron_archive_client_recordingStopped *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingStopped_sbe_position_ptr(
+    struct aeron_archive_client_recordingStopped *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_reset(
+    struct aeron_archive_client_recordingStopped *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingStopped_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_copy(
+    struct aeron_archive_client_recordingStopped *const codec,
+    const struct aeron_archive_client_recordingStopped *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStopped_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_STOPPED_SBE_TEMPLATE_ID (uint16_t)103
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStopped_sbe_template_id(void)
+{
+    return (uint16_t)103;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStopped_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStopped_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingStopped_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStopped_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_offset(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_wrap_and_apply_header(
+    struct aeron_archive_client_recordingStopped *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingStopped_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingStopped_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingStopped_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingStopped_sbe_schema_version());
+
+    aeron_archive_client_recordingStopped_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingStopped_sbe_block_length(),
+        aeron_archive_client_recordingStopped_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_wrap_for_encode(
+    struct aeron_archive_client_recordingStopped *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingStopped_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingStopped_sbe_block_length(),
+        aeron_archive_client_recordingStopped_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_wrap_for_decode(
+    struct aeron_archive_client_recordingStopped *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingStopped_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_sbe_rewind(
+    struct aeron_archive_client_recordingStopped *const codec)
+{
+    return aeron_archive_client_recordingStopped_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_encoded_length(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    return aeron_archive_client_recordingStopped_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStopped_buffer(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingStopped_mut_buffer(
+    struct aeron_archive_client_recordingStopped *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_buffer_length(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_acting_version(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStopped_recordingId_meta_attribute(
+    const enum aeron_archive_client_recordingStopped_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStopped_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStopped_recordingId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStopped_recordingId_in_acting_version(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStopped_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStopped_recordingId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStopped_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_recordingId(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_set_recordingId(
+    struct aeron_archive_client_recordingStopped *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStopped_startPosition_meta_attribute(
+    const enum aeron_archive_client_recordingStopped_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStopped_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStopped_startPosition_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_startPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStopped_startPosition_in_acting_version(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStopped_startPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStopped_startPosition_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_startPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_startPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_startPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStopped_startPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_startPosition(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_set_startPosition(
+    struct aeron_archive_client_recordingStopped *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingStopped_stopPosition_meta_attribute(
+    const enum aeron_archive_client_recordingStopped_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingStopped_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingStopped_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingStopped_stopPosition_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingStopped_stopPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingStopped_stopPosition_in_acting_version(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingStopped_stopPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStopped_stopPosition_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_stopPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_stopPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_stopPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingStopped_stopPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingStopped_stopPosition(
+    const struct aeron_archive_client_recordingStopped *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingStopped *aeron_archive_client_recordingStopped_set_stopPosition(
+    struct aeron_archive_client_recordingStopped *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingSubscriptionDescriptor.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/recordingSubscriptionDescriptor.h
@@ -1,0 +1,874 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_RECORDINGSUBSCRIPTIONDESCRIPTOR_H_
+#define _AERON_ARCHIVE_CLIENT_RECORDINGSUBSCRIPTIONDESCRIPTOR_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_recordingSubscriptionDescriptor
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute
+{
+    aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_EPOCH,
+    aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_TIME_UNIT,
+    aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_recordingSubscriptionDescriptor_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_recordingSubscriptionDescriptor_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_recordingSubscriptionDescriptor_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_recordingSubscriptionDescriptor_sbe_position_ptr(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_reset(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_copy(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_sbe_block_length(void)
+{
+    return (uint16_t)28;
+}
+
+#define AERON_ARCHIVE_CLIENT_RECORDING_SUBSCRIPTION_DESCRIPTOR_SBE_TEMPLATE_ID (uint16_t)23
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_sbe_template_id(void)
+{
+    return (uint16_t)23;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_recordingSubscriptionDescriptor_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_offset(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_wrap_and_apply_header(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_recordingSubscriptionDescriptor_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_recordingSubscriptionDescriptor_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_recordingSubscriptionDescriptor_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_recordingSubscriptionDescriptor_sbe_schema_version());
+
+    aeron_archive_client_recordingSubscriptionDescriptor_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_recordingSubscriptionDescriptor_sbe_block_length(),
+        aeron_archive_client_recordingSubscriptionDescriptor_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_wrap_for_encode(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingSubscriptionDescriptor_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_recordingSubscriptionDescriptor_sbe_block_length(),
+        aeron_archive_client_recordingSubscriptionDescriptor_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_wrap_for_decode(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_recordingSubscriptionDescriptor_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_sbe_rewind(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return aeron_archive_client_recordingSubscriptionDescriptor_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_encoded_length(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_buffer(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_recordingSubscriptionDescriptor_mut_buffer(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_buffer_length(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_acting_version(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_controlSessionId(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_set_controlSessionId(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_correlationId_meta_attribute(
+    const enum aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSubscriptionDescriptor_correlationId_in_acting_version(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSubscriptionDescriptor_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_correlationId(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_set_correlationId(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_meta_attribute(
+    const enum aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_in_acting_version(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_recordingSubscriptionDescriptor_subscriptionId(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_set_subscriptionId(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_streamId_meta_attribute(
+    const enum aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_streamId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSubscriptionDescriptor_streamId_in_acting_version(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSubscriptionDescriptor_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_streamId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingSubscriptionDescriptor_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingSubscriptionDescriptor_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingSubscriptionDescriptor_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_recordingSubscriptionDescriptor_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_recordingSubscriptionDescriptor_streamId(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_set_streamId(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_meta_attribute(
+    const enum aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_recordingSubscriptionDescriptor_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_in_acting_version(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_length(
+    const struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_recordingSubscriptionDescriptor_get_strippedChannel(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec);
+    if (!aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor_string_view aeron_archive_client_recordingSubscriptionDescriptor_get_strippedChannel_as_string_view(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_recordingSubscriptionDescriptor_strippedChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec) + 4;
+    if (!aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(
+        codec, aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_recordingSubscriptionDescriptor_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_recordingSubscriptionDescriptor_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_recordingSubscriptionDescriptor *aeron_archive_client_recordingSubscriptionDescriptor_put_strippedChannel(
+    struct aeron_archive_client_recordingSubscriptionDescriptor *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_recordingSubscriptionDescriptor_sbe_position(codec);
+
+    if (!aeron_archive_client_recordingSubscriptionDescriptor_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replayRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replayRequest.h
@@ -1,0 +1,1256 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_REPLAYREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_REPLAYREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_replayRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_replayRequest_meta_attribute
+{
+    aeron_archive_client_replayRequest_meta_attribute_EPOCH,
+    aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_replayRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_replayRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_replayRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_replayRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_sbe_position(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_set_sbe_position(
+    struct aeron_archive_client_replayRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_replayRequest_sbe_position_ptr(
+    struct aeron_archive_client_replayRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_reset(
+    struct aeron_archive_client_replayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_replayRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_copy(
+    struct aeron_archive_client_replayRequest *const codec,
+    const struct aeron_archive_client_replayRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_sbe_block_length(void)
+{
+    return (uint16_t)56;
+}
+
+#define AERON_ARCHIVE_CLIENT_REPLAY_REQUEST_SBE_TEMPLATE_ID (uint16_t)6
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_sbe_template_id(void)
+{
+    return (uint16_t)6;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_replayRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_offset(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_wrap_and_apply_header(
+    struct aeron_archive_client_replayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_replayRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_replayRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_replayRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_replayRequest_sbe_schema_version());
+
+    aeron_archive_client_replayRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_replayRequest_sbe_block_length(),
+        aeron_archive_client_replayRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_wrap_for_encode(
+    struct aeron_archive_client_replayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replayRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_replayRequest_sbe_block_length(),
+        aeron_archive_client_replayRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_wrap_for_decode(
+    struct aeron_archive_client_replayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replayRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_sbe_rewind(
+    struct aeron_archive_client_replayRequest *const codec)
+{
+    return aeron_archive_client_replayRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_encoded_length(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    return aeron_archive_client_replayRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_buffer(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_replayRequest_mut_buffer(
+    struct aeron_archive_client_replayRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_buffer_length(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_controlSessionId(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_controlSessionId(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_correlationId(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_correlationId(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_recordingId(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_recordingId(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_position_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_position_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_position_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_position_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_position_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_position_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_position_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_position_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_position_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_position_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_position(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_position(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_length_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_length_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_length_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_length_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_length_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_length_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_length_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_length_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_length_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_length_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_length(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_length(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_replayStreamId_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_replayStreamId_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_replayStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_replayStreamId_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_replayStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_replayStreamId_encoding_offset(void)
+{
+    return 40;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_replayStreamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_replayStreamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_replayStreamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_replayStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_replayStreamId(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 40, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_replayStreamId(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 40, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_fileIoMaxLength_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_fileIoMaxLength_id(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_fileIoMaxLength_since_version(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_fileIoMaxLength_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_fileIoMaxLength_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_fileIoMaxLength_encoding_offset(void)
+{
+    return 44;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_fileIoMaxLength_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_fileIoMaxLength_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_fileIoMaxLength_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_fileIoMaxLength_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replayRequest_fileIoMaxLength(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    if (codec->acting_version < 7)
+    {
+        return INT32_MIN;
+    }
+
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 44, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_fileIoMaxLength(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 44, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_replayToken_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_replayToken_id(void)
+{
+    return 9;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_replayToken_since_version(void)
+{
+    return 10;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_replayToken_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_replayToken_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_replayToken_encoding_offset(void)
+{
+    return 48;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_replayToken_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_replayToken_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_replayToken_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayRequest_replayToken_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayRequest_replayToken(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    if (codec->acting_version < 10)
+    {
+        return INT64_MIN;
+    }
+
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 48, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_set_replayToken(
+    struct aeron_archive_client_replayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 48, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_replayChannel_meta_attribute(
+    const enum aeron_archive_client_replayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_replayChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_replayChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayRequest_replayChannel_in_acting_version(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayRequest_replayChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayRequest_replayChannel_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_replayChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replayRequest_replayChannel_length(
+    const struct aeron_archive_client_replayRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replayRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayRequest_replayChannel(
+    struct aeron_archive_client_replayRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replayRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replayRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replayRequest_set_sbe_position(
+        codec, aeron_archive_client_replayRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayRequest_get_replayChannel(
+    struct aeron_archive_client_replayRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replayRequest_sbe_position(codec);
+    if (!aeron_archive_client_replayRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replayRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_replayRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest_string_view aeron_archive_client_replayRequest_get_replayChannel_as_string_view(
+    struct aeron_archive_client_replayRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_replayRequest_replayChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replayRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replayRequest_set_sbe_position(
+        codec, aeron_archive_client_replayRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replayRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replayRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayRequest *aeron_archive_client_replayRequest_put_replayChannel(
+    struct aeron_archive_client_replayRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replayRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replayRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replayRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_replayRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replayTokenRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replayTokenRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_REPLAYTOKENREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_REPLAYTOKENREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_replayTokenRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_replayTokenRequest_meta_attribute
+{
+    aeron_archive_client_replayTokenRequest_meta_attribute_EPOCH,
+    aeron_archive_client_replayTokenRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_replayTokenRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_replayTokenRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_replayTokenRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_replayTokenRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_replayTokenRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_sbe_position(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayTokenRequest_set_sbe_position(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_replayTokenRequest_sbe_position_ptr(
+    struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_reset(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_replayTokenRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_copy(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    const struct aeron_archive_client_replayTokenRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayTokenRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_REPLAY_TOKEN_REQUEST_SBE_TEMPLATE_ID (uint16_t)105
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayTokenRequest_sbe_template_id(void)
+{
+    return (uint16_t)105;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayTokenRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayTokenRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_replayTokenRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayTokenRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_offset(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_wrap_and_apply_header(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_replayTokenRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_replayTokenRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_replayTokenRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_replayTokenRequest_sbe_schema_version());
+
+    aeron_archive_client_replayTokenRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_replayTokenRequest_sbe_block_length(),
+        aeron_archive_client_replayTokenRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_wrap_for_encode(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replayTokenRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_replayTokenRequest_sbe_block_length(),
+        aeron_archive_client_replayTokenRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_wrap_for_decode(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replayTokenRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_sbe_rewind(
+    struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return aeron_archive_client_replayTokenRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_encoded_length(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return aeron_archive_client_replayTokenRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayTokenRequest_buffer(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_replayTokenRequest_mut_buffer(
+    struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_buffer_length(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_acting_version(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayTokenRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_replayTokenRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayTokenRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayTokenRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayTokenRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayTokenRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayTokenRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayTokenRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_controlSessionId(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_set_controlSessionId(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayTokenRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_replayTokenRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayTokenRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayTokenRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayTokenRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayTokenRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayTokenRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayTokenRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_correlationId(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_set_correlationId(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replayTokenRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_replayTokenRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replayTokenRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replayTokenRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replayTokenRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replayTokenRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replayTokenRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replayTokenRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayTokenRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replayTokenRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replayTokenRequest_recordingId(
+    const struct aeron_archive_client_replayTokenRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replayTokenRequest *aeron_archive_client_replayTokenRequest_set_recordingId(
+    struct aeron_archive_client_replayTokenRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replicateRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replicateRequest.h
@@ -1,0 +1,1110 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_REPLICATEREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_REPLICATEREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_replicateRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_replicateRequest_meta_attribute
+{
+    aeron_archive_client_replicateRequest_meta_attribute_EPOCH,
+    aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_replicateRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_replicateRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_replicateRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_replicateRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_sbe_position(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_set_sbe_position(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_replicateRequest_sbe_position_ptr(
+    struct aeron_archive_client_replicateRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_reset(
+    struct aeron_archive_client_replicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_copy(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const struct aeron_archive_client_replicateRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_sbe_block_length(void)
+{
+    return (uint16_t)36;
+}
+
+#define AERON_ARCHIVE_CLIENT_REPLICATE_REQUEST_SBE_TEMPLATE_ID (uint16_t)50
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_sbe_template_id(void)
+{
+    return (uint16_t)50;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_replicateRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_offset(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_wrap_and_apply_header(
+    struct aeron_archive_client_replicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_replicateRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_replicateRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_replicateRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_replicateRequest_sbe_schema_version());
+
+    aeron_archive_client_replicateRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_replicateRequest_sbe_block_length(),
+        aeron_archive_client_replicateRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_wrap_for_encode(
+    struct aeron_archive_client_replicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replicateRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_replicateRequest_sbe_block_length(),
+        aeron_archive_client_replicateRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_wrap_for_decode(
+    struct aeron_archive_client_replicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replicateRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_sbe_rewind(
+    struct aeron_archive_client_replicateRequest *const codec)
+{
+    return aeron_archive_client_replicateRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_encoded_length(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    return aeron_archive_client_replicateRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_buffer(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_replicateRequest_mut_buffer(
+    struct aeron_archive_client_replicateRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_buffer_length(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_controlSessionId(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_set_controlSessionId(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_correlationId(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_set_correlationId(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_srcRecordingId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_srcRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_srcRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_srcRecordingId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest_srcRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_srcRecordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_srcRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_srcRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_srcRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_srcRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_srcRecordingId(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_set_srcRecordingId(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_dstRecordingId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_dstRecordingId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_dstRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_dstRecordingId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest_dstRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_dstRecordingId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_dstRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_dstRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_dstRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_dstRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest_dstRecordingId(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_set_dstRecordingId(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_srcControlStreamId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_srcControlStreamId_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_srcControlStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_srcControlStreamId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest_srcControlStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_srcControlStreamId_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest_srcControlStreamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest_srcControlStreamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest_srcControlStreamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest_srcControlStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest_srcControlStreamId(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_set_srcControlStreamId(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_srcControlChannel_meta_attribute(
+    const enum aeron_archive_client_replicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_srcControlChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_srcControlChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_srcControlChannel_in_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest_srcControlChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_srcControlChannel_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_srcControlChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replicateRequest_srcControlChannel_length(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_srcControlChannel(
+    struct aeron_archive_client_replicateRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_get_srcControlChannel(
+    struct aeron_archive_client_replicateRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest_sbe_position(codec);
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest_string_view aeron_archive_client_replicateRequest_get_srcControlChannel_as_string_view(
+    struct aeron_archive_client_replicateRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_replicateRequest_srcControlChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replicateRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replicateRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_put_srcControlChannel(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_liveDestination_meta_attribute(
+    const enum aeron_archive_client_replicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_liveDestination_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_liveDestination_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest_liveDestination_in_acting_version(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest_liveDestination_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest_liveDestination_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_liveDestination_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replicateRequest_liveDestination_length(
+    const struct aeron_archive_client_replicateRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest_liveDestination(
+    struct aeron_archive_client_replicateRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest_get_liveDestination(
+    struct aeron_archive_client_replicateRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest_sbe_position(codec);
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest_string_view aeron_archive_client_replicateRequest_get_liveDestination_as_string_view(
+    struct aeron_archive_client_replicateRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_replicateRequest_liveDestination_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replicateRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replicateRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replicateRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest *aeron_archive_client_replicateRequest_put_liveDestination(
+    struct aeron_archive_client_replicateRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replicateRequest2.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/replicateRequest2.h
@@ -1,0 +1,2056 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_REPLICATEREQUEST2_H_
+#define _AERON_ARCHIVE_CLIENT_REPLICATEREQUEST2_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_replicateRequest2
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_replicateRequest2_meta_attribute
+{
+    aeron_archive_client_replicateRequest2_meta_attribute_EPOCH,
+    aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT,
+    aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_replicateRequest2_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_replicateRequest2_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_replicateRequest2_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_sbe_position(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_set_sbe_position(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_replicateRequest2_sbe_position_ptr(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_reset(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_copy(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const struct aeron_archive_client_replicateRequest2 *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_sbe_block_length(void)
+{
+    return (uint16_t)68;
+}
+
+#define AERON_ARCHIVE_CLIENT_REPLICATE_REQUEST2_SBE_TEMPLATE_ID (uint16_t)66
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_sbe_template_id(void)
+{
+    return (uint16_t)66;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_replicateRequest2_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_offset(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_wrap_and_apply_header(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_replicateRequest2_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_replicateRequest2_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_replicateRequest2_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_replicateRequest2_sbe_schema_version());
+
+    aeron_archive_client_replicateRequest2_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_replicateRequest2_sbe_block_length(),
+        aeron_archive_client_replicateRequest2_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_wrap_for_encode(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replicateRequest2_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_replicateRequest2_sbe_block_length(),
+        aeron_archive_client_replicateRequest2_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_wrap_for_decode(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_replicateRequest2_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_sbe_rewind(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return aeron_archive_client_replicateRequest2_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_encoded_length(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return aeron_archive_client_replicateRequest2_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_buffer(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_replicateRequest2_mut_buffer(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_buffer_length(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_controlSessionId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_controlSessionId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_correlationId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_correlationId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_correlationId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_correlationId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcRecordingId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_srcRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_srcRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_srcRecordingId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_srcRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_srcRecordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_srcRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_srcRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_srcRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_srcRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_srcRecordingId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_srcRecordingId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_dstRecordingId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_dstRecordingId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_dstRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_dstRecordingId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_dstRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_dstRecordingId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_dstRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_dstRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_dstRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_dstRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_dstRecordingId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_dstRecordingId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_stopPosition_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_stopPosition_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_stopPosition_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_stopPosition_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_stopPosition_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_stopPosition_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_stopPosition_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_stopPosition_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_stopPosition_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_stopPosition_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_stopPosition(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_stopPosition(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_channelTagId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_channelTagId_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_channelTagId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_channelTagId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_channelTagId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_channelTagId_encoding_offset(void)
+{
+    return 40;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_channelTagId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_channelTagId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_channelTagId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_channelTagId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_channelTagId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 40, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_channelTagId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 40, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_subscriptionTagId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_subscriptionTagId_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_subscriptionTagId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_subscriptionTagId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_subscriptionTagId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_subscriptionTagId_encoding_offset(void)
+{
+    return 48;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_subscriptionTagId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_subscriptionTagId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_subscriptionTagId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_subscriptionTagId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_replicateRequest2_subscriptionTagId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 48, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_subscriptionTagId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 48, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcControlStreamId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_srcControlStreamId_id(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_srcControlStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_srcControlStreamId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_srcControlStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_srcControlStreamId_encoding_offset(void)
+{
+    return 56;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_srcControlStreamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_srcControlStreamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_srcControlStreamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_srcControlStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_srcControlStreamId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 56, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_srcControlStreamId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 56, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_fileIoMaxLength_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_fileIoMaxLength_id(void)
+{
+    return 12;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_fileIoMaxLength_since_version(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_fileIoMaxLength_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_fileIoMaxLength_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_fileIoMaxLength_encoding_offset(void)
+{
+    return 60;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_fileIoMaxLength_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_fileIoMaxLength_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_fileIoMaxLength_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_fileIoMaxLength_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_fileIoMaxLength(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 7)
+    {
+        return INT32_MIN;
+    }
+
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 60, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_fileIoMaxLength(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 60, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_replicationSessionId_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_replicationSessionId_id(void)
+{
+    return 13;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_replicationSessionId_since_version(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_replicationSessionId_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_replicationSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_replicationSessionId_encoding_offset(void)
+{
+    return 64;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_replicationSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_replicationSessionId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_replicationSessionId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_replicateRequest2_replicationSessionId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_replicateRequest2_replicationSessionId(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 8)
+    {
+        return INT32_MIN;
+    }
+
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 64, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_set_replicationSessionId(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 64, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcControlChannel_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcControlChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_srcControlChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_srcControlChannel_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_srcControlChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_srcControlChannel_id(void)
+{
+    return 9;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_srcControlChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replicateRequest2_srcControlChannel_length(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcControlChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_get_srcControlChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2_string_view aeron_archive_client_replicateRequest2_get_srcControlChannel_as_string_view(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_replicateRequest2_srcControlChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replicateRequest2_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replicateRequest2_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_put_srcControlChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_liveDestination_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_liveDestination_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_liveDestination_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_liveDestination_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_liveDestination_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_liveDestination_id(void)
+{
+    return 10;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_liveDestination_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replicateRequest2_liveDestination_length(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_liveDestination(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_get_liveDestination(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2_string_view aeron_archive_client_replicateRequest2_get_liveDestination_as_string_view(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_replicateRequest2_liveDestination_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replicateRequest2_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replicateRequest2_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_put_liveDestination(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_replicationChannel_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_replicationChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_replicationChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_replicationChannel_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_replicationChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_replicationChannel_id(void)
+{
+    return 11;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_replicationChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replicateRequest2_replicationChannel_length(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_replicationChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_get_replicationChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2_string_view aeron_archive_client_replicateRequest2_get_replicationChannel_as_string_view(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_replicateRequest2_replicationChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replicateRequest2_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replicateRequest2_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_put_replicationChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_encodedCredentials_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_encodedCredentials_character_encoding(void)
+{
+    return "null";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_encodedCredentials_since_version(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_encodedCredentials_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_encodedCredentials_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_encodedCredentials_id(void)
+{
+    return 14;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_encodedCredentials_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replicateRequest2_encodedCredentials_length(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 8)
+    {
+        return 0;
+    }
+
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_encodedCredentials(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 8)
+    {
+        return NULL;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_get_encodedCredentials(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    if (codec->acting_version < 8)
+    {
+        return 0;
+    }
+
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2_string_view aeron_archive_client_replicateRequest2_get_encodedCredentials_as_string_view(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 8)
+    {
+        struct aeron_archive_client_replicateRequest2_string_view ret = { NULL, 0 };
+        return ret;
+    }
+
+    uint32_t length_field_value = aeron_archive_client_replicateRequest2_encodedCredentials_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replicateRequest2_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replicateRequest2_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_put_encodedCredentials(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcResponseChannel_meta_attribute(
+    const enum aeron_archive_client_replicateRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_replicateRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_replicateRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcResponseChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_srcResponseChannel_since_version(void)
+{
+    return 10;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_replicateRequest2_srcResponseChannel_in_acting_version(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_replicateRequest2_srcResponseChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_replicateRequest2_srcResponseChannel_id(void)
+{
+    return 15;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_srcResponseChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_replicateRequest2_srcResponseChannel_length(
+    const struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 10)
+    {
+        return 0;
+    }
+
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_replicateRequest2_srcResponseChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 10)
+    {
+        return NULL;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_replicateRequest2_get_srcResponseChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    if (codec->acting_version < 10)
+    {
+        return 0;
+    }
+
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2_string_view aeron_archive_client_replicateRequest2_get_srcResponseChannel_as_string_view(
+    struct aeron_archive_client_replicateRequest2 *const codec)
+{
+    if (codec->acting_version < 10)
+    {
+        struct aeron_archive_client_replicateRequest2_string_view ret = { NULL, 0 };
+        return ret;
+    }
+
+    uint32_t length_field_value = aeron_archive_client_replicateRequest2_srcResponseChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_replicateRequest2_sbe_position(codec) + 4;
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(
+        codec, aeron_archive_client_replicateRequest2_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_replicateRequest2_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_replicateRequest2_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_replicateRequest2 *aeron_archive_client_replicateRequest2_put_srcResponseChannel(
+    struct aeron_archive_client_replicateRequest2 *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_replicateRequest2_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_replicateRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_replicateRequest2_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/sourceLocation.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/sourceLocation.h
@@ -1,0 +1,143 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_SOURCELOCATION_H_
+#define _AERON_ARCHIVE_CLIENT_SOURCELOCATION_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+enum aeron_archive_client_sourceLocation
+{
+    aeron_archive_client_sourceLocation_LOCAL = INT32_C(0),
+    aeron_archive_client_sourceLocation_REMOTE = INT32_C(1),
+    aeron_archive_client_sourceLocation_NULL_VALUE = INT32_MIN
+};
+
+SBE_ONE_DEF bool aeron_archive_client_sourceLocation_get(
+    const int32_t value,
+    enum aeron_archive_client_sourceLocation *const out)
+{
+    switch (value)
+    {
+        case INT32_C(0):
+             *out = aeron_archive_client_sourceLocation_LOCAL;
+             return true;
+        case INT32_C(1):
+             *out = aeron_archive_client_sourceLocation_REMOTE;
+             return true;
+        case INT32_MIN:
+             *out = aeron_archive_client_sourceLocation_NULL_VALUE;
+             return true;
+    }
+
+    errno = E103;
+    return false;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/startPositionRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/startPositionRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STARTPOSITIONREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STARTPOSITIONREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_startPositionRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_startPositionRequest_meta_attribute
+{
+    aeron_archive_client_startPositionRequest_meta_attribute_EPOCH,
+    aeron_archive_client_startPositionRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_startPositionRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_startPositionRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_startPositionRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_startPositionRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_startPositionRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_sbe_position(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startPositionRequest_set_sbe_position(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_startPositionRequest_sbe_position_ptr(
+    struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_reset(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_startPositionRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_copy(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    const struct aeron_archive_client_startPositionRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startPositionRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_START_POSITION_REQUEST_SBE_TEMPLATE_ID (uint16_t)52
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startPositionRequest_sbe_template_id(void)
+{
+    return (uint16_t)52;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startPositionRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startPositionRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_startPositionRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startPositionRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_offset(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_wrap_and_apply_header(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_startPositionRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_startPositionRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_startPositionRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_startPositionRequest_sbe_schema_version());
+
+    aeron_archive_client_startPositionRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_startPositionRequest_sbe_block_length(),
+        aeron_archive_client_startPositionRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_wrap_for_encode(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_startPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_startPositionRequest_sbe_block_length(),
+        aeron_archive_client_startPositionRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_wrap_for_decode(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_startPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_sbe_rewind(
+    struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return aeron_archive_client_startPositionRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_encoded_length(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return aeron_archive_client_startPositionRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startPositionRequest_buffer(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_startPositionRequest_mut_buffer(
+    struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_buffer_length(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_acting_version(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startPositionRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_startPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startPositionRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startPositionRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startPositionRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startPositionRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startPositionRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_controlSessionId(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_set_controlSessionId(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startPositionRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_startPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startPositionRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startPositionRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startPositionRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startPositionRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startPositionRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_correlationId(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_set_correlationId(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startPositionRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_startPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startPositionRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startPositionRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startPositionRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startPositionRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startPositionRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startPositionRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startPositionRequest_recordingId(
+    const struct aeron_archive_client_startPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startPositionRequest *aeron_archive_client_startPositionRequest_set_recordingId(
+    struct aeron_archive_client_startPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/startRecordingRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/startRecordingRequest.h
@@ -1,0 +1,848 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STARTRECORDINGREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STARTRECORDINGREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_startRecordingRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_startRecordingRequest_meta_attribute
+{
+    aeron_archive_client_startRecordingRequest_meta_attribute_EPOCH,
+    aeron_archive_client_startRecordingRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_startRecordingRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_startRecordingRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_startRecordingRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_startRecordingRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_startRecordingRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_sbe_position(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest_set_sbe_position(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_startRecordingRequest_sbe_position_ptr(
+    struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_reset(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_startRecordingRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_copy(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    const struct aeron_archive_client_startRecordingRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_START_RECORDING_REQUEST_SBE_TEMPLATE_ID (uint16_t)4
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_sbe_template_id(void)
+{
+    return (uint16_t)4;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_startRecordingRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_offset(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_wrap_and_apply_header(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_startRecordingRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_startRecordingRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_startRecordingRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_startRecordingRequest_sbe_schema_version());
+
+    aeron_archive_client_startRecordingRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_startRecordingRequest_sbe_block_length(),
+        aeron_archive_client_startRecordingRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_wrap_for_encode(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_startRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_startRecordingRequest_sbe_block_length(),
+        aeron_archive_client_startRecordingRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_wrap_for_decode(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_startRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_sbe_rewind(
+    struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return aeron_archive_client_startRecordingRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_encoded_length(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return aeron_archive_client_startRecordingRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_buffer(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_startRecordingRequest_mut_buffer(
+    struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_buffer_length(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_acting_version(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_controlSessionId(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_set_controlSessionId(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest_correlationId(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_set_correlationId(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_streamId_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_streamId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest_streamId_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_streamId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest_streamId(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_set_streamId(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_sourceLocation_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_sourceLocation_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_sourceLocation_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest_sourceLocation_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest_sourceLocation_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_sourceLocation_encoding_offset(void)
+{
+    return 20;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest_sourceLocation_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest_sourceLocation(
+    const struct aeron_archive_client_startRecordingRequest *const codec,
+    enum aeron_archive_client_sourceLocation *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 20, sizeof(int32_t));
+
+    return aeron_archive_client_sourceLocation_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_set_sourceLocation(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    const enum aeron_archive_client_sourceLocation value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 20, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_channel_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest_channel_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest_channel_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_startRecordingRequest_channel_length(
+    const struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_startRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest_channel(
+    struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_startRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_startRecordingRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_startRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_startRecordingRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest_get_channel(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_startRecordingRequest_sbe_position(codec);
+    if (!aeron_archive_client_startRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_startRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_startRecordingRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest_string_view aeron_archive_client_startRecordingRequest_get_channel_as_string_view(
+    struct aeron_archive_client_startRecordingRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_startRecordingRequest_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_startRecordingRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_startRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_startRecordingRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_startRecordingRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_startRecordingRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest *aeron_archive_client_startRecordingRequest_put_channel(
+    struct aeron_archive_client_startRecordingRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_startRecordingRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_startRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_startRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_startRecordingRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/startRecordingRequest2.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/startRecordingRequest2.h
@@ -1,0 +1,915 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STARTRECORDINGREQUEST2_H_
+#define _AERON_ARCHIVE_CLIENT_STARTRECORDINGREQUEST2_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_startRecordingRequest2
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_startRecordingRequest2_meta_attribute
+{
+    aeron_archive_client_startRecordingRequest2_meta_attribute_EPOCH,
+    aeron_archive_client_startRecordingRequest2_meta_attribute_TIME_UNIT,
+    aeron_archive_client_startRecordingRequest2_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_startRecordingRequest2_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_startRecordingRequest2_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_startRecordingRequest2_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_startRecordingRequest2_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_sbe_position(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_set_sbe_position(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_startRecordingRequest2_sbe_position_ptr(
+    struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_reset(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_startRecordingRequest2_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_copy(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const struct aeron_archive_client_startRecordingRequest2 *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_sbe_block_length(void)
+{
+    return (uint16_t)28;
+}
+
+#define AERON_ARCHIVE_CLIENT_START_RECORDING_REQUEST2_SBE_TEMPLATE_ID (uint16_t)63
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_sbe_template_id(void)
+{
+    return (uint16_t)63;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_startRecordingRequest2_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_offset(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_wrap_and_apply_header(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_startRecordingRequest2_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_startRecordingRequest2_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_startRecordingRequest2_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_startRecordingRequest2_sbe_schema_version());
+
+    aeron_archive_client_startRecordingRequest2_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_startRecordingRequest2_sbe_block_length(),
+        aeron_archive_client_startRecordingRequest2_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_wrap_for_encode(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_startRecordingRequest2_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_startRecordingRequest2_sbe_block_length(),
+        aeron_archive_client_startRecordingRequest2_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_wrap_for_decode(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_startRecordingRequest2_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_sbe_rewind(
+    struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return aeron_archive_client_startRecordingRequest2_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_encoded_length(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return aeron_archive_client_startRecordingRequest2_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_buffer(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_startRecordingRequest2_mut_buffer(
+    struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_buffer_length(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_acting_version(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest2_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_controlSessionId(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_set_controlSessionId(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_correlationId_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_correlationId_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest2_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_startRecordingRequest2_correlationId(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_set_correlationId(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_streamId_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_streamId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_streamId_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest2_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_streamId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest2_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest2_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest2_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_startRecordingRequest2_streamId(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_set_streamId(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_sourceLocation_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_sourceLocation_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_sourceLocation_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_sourceLocation_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest2_sourceLocation_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_sourceLocation_encoding_offset(void)
+{
+    return 20;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_sourceLocation_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_sourceLocation(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec,
+    enum aeron_archive_client_sourceLocation *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 20, sizeof(int32_t));
+
+    return aeron_archive_client_sourceLocation_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_set_sourceLocation(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const enum aeron_archive_client_sourceLocation value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 20, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_autoStop_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_autoStop_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_autoStop_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_autoStop_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest2_autoStop_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_autoStop_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_startRecordingRequest2_autoStop_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_autoStop(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec,
+    enum aeron_archive_client_booleanType *const out)
+{
+    int32_t val;
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int32_t));
+
+    return aeron_archive_client_booleanType_get(SBE_LITTLE_ENDIAN_ENCODE_32(val), out);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_set_autoStop(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const enum aeron_archive_client_booleanType value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int32_t));
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_channel_meta_attribute(
+    const enum aeron_archive_client_startRecordingRequest2_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_startRecordingRequest2_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_startRecordingRequest2_channel_in_acting_version(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_startRecordingRequest2_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_startRecordingRequest2_channel_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_startRecordingRequest2_channel_length(
+    const struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_startRecordingRequest2_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_startRecordingRequest2_channel(
+    struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_startRecordingRequest2_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_startRecordingRequest2_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_startRecordingRequest2_set_sbe_position(
+        codec, aeron_archive_client_startRecordingRequest2_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_startRecordingRequest2_get_channel(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_startRecordingRequest2_sbe_position(codec);
+    if (!aeron_archive_client_startRecordingRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_startRecordingRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_startRecordingRequest2_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2_string_view aeron_archive_client_startRecordingRequest2_get_channel_as_string_view(
+    struct aeron_archive_client_startRecordingRequest2 *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_startRecordingRequest2_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_startRecordingRequest2_sbe_position(codec) + 4;
+    if (!aeron_archive_client_startRecordingRequest2_set_sbe_position(
+        codec, aeron_archive_client_startRecordingRequest2_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_startRecordingRequest2_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_startRecordingRequest2_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_startRecordingRequest2 *aeron_archive_client_startRecordingRequest2_put_channel(
+    struct aeron_archive_client_startRecordingRequest2 *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_startRecordingRequest2_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_startRecordingRequest2_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_startRecordingRequest2_sbe_position(codec);
+
+    if (!aeron_archive_client_startRecordingRequest2_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopAllReplaysRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopAllReplaysRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STOPALLREPLAYSREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STOPALLREPLAYSREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_stopAllReplaysRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_stopAllReplaysRequest_meta_attribute
+{
+    aeron_archive_client_stopAllReplaysRequest_meta_attribute_EPOCH,
+    aeron_archive_client_stopAllReplaysRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_stopAllReplaysRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_stopAllReplaysRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_stopAllReplaysRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_stopAllReplaysRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_stopAllReplaysRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_sbe_position(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopAllReplaysRequest_set_sbe_position(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_stopAllReplaysRequest_sbe_position_ptr(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_reset(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_stopAllReplaysRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_copy(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    const struct aeron_archive_client_stopAllReplaysRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopAllReplaysRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_STOP_ALL_REPLAYS_REQUEST_SBE_TEMPLATE_ID (uint16_t)19
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopAllReplaysRequest_sbe_template_id(void)
+{
+    return (uint16_t)19;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopAllReplaysRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopAllReplaysRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_stopAllReplaysRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopAllReplaysRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_offset(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_wrap_and_apply_header(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_stopAllReplaysRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_stopAllReplaysRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_stopAllReplaysRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_stopAllReplaysRequest_sbe_schema_version());
+
+    aeron_archive_client_stopAllReplaysRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_stopAllReplaysRequest_sbe_block_length(),
+        aeron_archive_client_stopAllReplaysRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_wrap_for_encode(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopAllReplaysRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_stopAllReplaysRequest_sbe_block_length(),
+        aeron_archive_client_stopAllReplaysRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_wrap_for_decode(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopAllReplaysRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_sbe_rewind(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return aeron_archive_client_stopAllReplaysRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_encoded_length(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return aeron_archive_client_stopAllReplaysRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopAllReplaysRequest_buffer(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_stopAllReplaysRequest_mut_buffer(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_buffer_length(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_acting_version(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopAllReplaysRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_stopAllReplaysRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopAllReplaysRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopAllReplaysRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopAllReplaysRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopAllReplaysRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopAllReplaysRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_controlSessionId(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_set_controlSessionId(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopAllReplaysRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_stopAllReplaysRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopAllReplaysRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopAllReplaysRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopAllReplaysRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopAllReplaysRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopAllReplaysRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_correlationId(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_set_correlationId(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopAllReplaysRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_stopAllReplaysRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopAllReplaysRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopAllReplaysRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopAllReplaysRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopAllReplaysRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopAllReplaysRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopAllReplaysRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopAllReplaysRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopAllReplaysRequest_recordingId(
+    const struct aeron_archive_client_stopAllReplaysRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopAllReplaysRequest *aeron_archive_client_stopAllReplaysRequest_set_recordingId(
+    struct aeron_archive_client_stopAllReplaysRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopPositionRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopPositionRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STOPPOSITIONREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STOPPOSITIONREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_stopPositionRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_stopPositionRequest_meta_attribute
+{
+    aeron_archive_client_stopPositionRequest_meta_attribute_EPOCH,
+    aeron_archive_client_stopPositionRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_stopPositionRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_stopPositionRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_stopPositionRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_stopPositionRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_stopPositionRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_sbe_position(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopPositionRequest_set_sbe_position(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_stopPositionRequest_sbe_position_ptr(
+    struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_reset(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_stopPositionRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_copy(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    const struct aeron_archive_client_stopPositionRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopPositionRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_STOP_POSITION_REQUEST_SBE_TEMPLATE_ID (uint16_t)15
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopPositionRequest_sbe_template_id(void)
+{
+    return (uint16_t)15;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopPositionRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopPositionRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_stopPositionRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopPositionRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_offset(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_wrap_and_apply_header(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_stopPositionRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_stopPositionRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_stopPositionRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_stopPositionRequest_sbe_schema_version());
+
+    aeron_archive_client_stopPositionRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_stopPositionRequest_sbe_block_length(),
+        aeron_archive_client_stopPositionRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_wrap_for_encode(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_stopPositionRequest_sbe_block_length(),
+        aeron_archive_client_stopPositionRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_wrap_for_decode(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopPositionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_sbe_rewind(
+    struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return aeron_archive_client_stopPositionRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_encoded_length(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return aeron_archive_client_stopPositionRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopPositionRequest_buffer(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_stopPositionRequest_mut_buffer(
+    struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_buffer_length(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_acting_version(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopPositionRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_stopPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopPositionRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopPositionRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopPositionRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopPositionRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopPositionRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_controlSessionId(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_set_controlSessionId(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopPositionRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_stopPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopPositionRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopPositionRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopPositionRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopPositionRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopPositionRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_correlationId(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_set_correlationId(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopPositionRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_stopPositionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopPositionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopPositionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopPositionRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopPositionRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopPositionRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopPositionRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopPositionRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopPositionRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopPositionRequest_recordingId(
+    const struct aeron_archive_client_stopPositionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopPositionRequest *aeron_archive_client_stopPositionRequest_set_recordingId(
+    struct aeron_archive_client_stopPositionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopRecordingByIdentityRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopRecordingByIdentityRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STOPRECORDINGBYIDENTITYREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STOPRECORDINGBYIDENTITYREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_stopRecordingByIdentityRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute
+{
+    aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_EPOCH,
+    aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_stopRecordingByIdentityRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_stopRecordingByIdentityRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_stopRecordingByIdentityRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_sbe_position(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingByIdentityRequest_set_sbe_position(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_stopRecordingByIdentityRequest_sbe_position_ptr(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_reset(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_stopRecordingByIdentityRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_copy(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingByIdentityRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_STOP_RECORDING_BY_IDENTITY_REQUEST_SBE_TEMPLATE_ID (uint16_t)65
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingByIdentityRequest_sbe_template_id(void)
+{
+    return (uint16_t)65;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingByIdentityRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingByIdentityRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_stopRecordingByIdentityRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingByIdentityRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_offset(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_wrap_and_apply_header(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_stopRecordingByIdentityRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_stopRecordingByIdentityRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_stopRecordingByIdentityRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_stopRecordingByIdentityRequest_sbe_schema_version());
+
+    aeron_archive_client_stopRecordingByIdentityRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_stopRecordingByIdentityRequest_sbe_block_length(),
+        aeron_archive_client_stopRecordingByIdentityRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_wrap_for_encode(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopRecordingByIdentityRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_stopRecordingByIdentityRequest_sbe_block_length(),
+        aeron_archive_client_stopRecordingByIdentityRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_wrap_for_decode(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopRecordingByIdentityRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_sbe_rewind(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return aeron_archive_client_stopRecordingByIdentityRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_encoded_length(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return aeron_archive_client_stopRecordingByIdentityRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingByIdentityRequest_buffer(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_stopRecordingByIdentityRequest_mut_buffer(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_buffer_length(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_acting_version(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_controlSessionId(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_set_controlSessionId(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingByIdentityRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingByIdentityRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingByIdentityRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_correlationId(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_set_correlationId(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingByIdentityRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingByIdentityRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingByIdentityRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingByIdentityRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingByIdentityRequest_recordingId(
+    const struct aeron_archive_client_stopRecordingByIdentityRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingByIdentityRequest *aeron_archive_client_stopRecordingByIdentityRequest_set_recordingId(
+    struct aeron_archive_client_stopRecordingByIdentityRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopRecordingRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopRecordingRequest.h
@@ -1,0 +1,781 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STOPRECORDINGREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STOPRECORDINGREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_stopRecordingRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_stopRecordingRequest_meta_attribute
+{
+    aeron_archive_client_stopRecordingRequest_meta_attribute_EPOCH,
+    aeron_archive_client_stopRecordingRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_stopRecordingRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_stopRecordingRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_stopRecordingRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_stopRecordingRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_stopRecordingRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_sbe_position(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingRequest_set_sbe_position(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_stopRecordingRequest_sbe_position_ptr(
+    struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_reset(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_stopRecordingRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_copy(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    const struct aeron_archive_client_stopRecordingRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_sbe_block_length(void)
+{
+    return (uint16_t)20;
+}
+
+#define AERON_ARCHIVE_CLIENT_STOP_RECORDING_REQUEST_SBE_TEMPLATE_ID (uint16_t)5
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_sbe_template_id(void)
+{
+    return (uint16_t)5;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_stopRecordingRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_offset(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_wrap_and_apply_header(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_stopRecordingRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_stopRecordingRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_stopRecordingRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_stopRecordingRequest_sbe_schema_version());
+
+    aeron_archive_client_stopRecordingRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_stopRecordingRequest_sbe_block_length(),
+        aeron_archive_client_stopRecordingRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_wrap_for_encode(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_stopRecordingRequest_sbe_block_length(),
+        aeron_archive_client_stopRecordingRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_wrap_for_decode(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_sbe_rewind(
+    struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return aeron_archive_client_stopRecordingRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_encoded_length(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return aeron_archive_client_stopRecordingRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_buffer(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_stopRecordingRequest_mut_buffer(
+    struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_buffer_length(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_acting_version(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_controlSessionId(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_set_controlSessionId(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingRequest_correlationId(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_set_correlationId(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_streamId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_streamId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_streamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingRequest_streamId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingRequest_streamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingRequest_streamId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_stopRecordingRequest_streamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_stopRecordingRequest_streamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_stopRecordingRequest_streamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingRequest_streamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_stopRecordingRequest_streamId(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_set_streamId(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_channel_meta_attribute(
+    const enum aeron_archive_client_stopRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_channel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_channel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingRequest_channel_in_acting_version(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingRequest_channel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingRequest_channel_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_channel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_stopRecordingRequest_channel_length(
+    const struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_stopRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingRequest_channel(
+    struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_stopRecordingRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_stopRecordingRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_stopRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_stopRecordingRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingRequest_get_channel(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_stopRecordingRequest_sbe_position(codec);
+    if (!aeron_archive_client_stopRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_stopRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_stopRecordingRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest_string_view aeron_archive_client_stopRecordingRequest_get_channel_as_string_view(
+    struct aeron_archive_client_stopRecordingRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_stopRecordingRequest_channel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_stopRecordingRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_stopRecordingRequest_set_sbe_position(
+        codec, aeron_archive_client_stopRecordingRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_stopRecordingRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_stopRecordingRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingRequest *aeron_archive_client_stopRecordingRequest_put_channel(
+    struct aeron_archive_client_stopRecordingRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_stopRecordingRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_stopRecordingRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_stopRecordingRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_stopRecordingRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopRecordingSubscriptionRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopRecordingSubscriptionRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STOPRECORDINGSUBSCRIPTIONREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STOPRECORDINGSUBSCRIPTIONREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_stopRecordingSubscriptionRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute
+{
+    aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_EPOCH,
+    aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_stopRecordingSubscriptionRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_stopRecordingSubscriptionRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_stopRecordingSubscriptionRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_sbe_position(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingSubscriptionRequest_set_sbe_position(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_stopRecordingSubscriptionRequest_sbe_position_ptr(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_reset(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_stopRecordingSubscriptionRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_copy(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingSubscriptionRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_STOP_RECORDING_SUBSCRIPTION_REQUEST_SBE_TEMPLATE_ID (uint16_t)14
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingSubscriptionRequest_sbe_template_id(void)
+{
+    return (uint16_t)14;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingSubscriptionRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingSubscriptionRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_stopRecordingSubscriptionRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingSubscriptionRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_offset(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_wrap_and_apply_header(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_stopRecordingSubscriptionRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_stopRecordingSubscriptionRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_stopRecordingSubscriptionRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_stopRecordingSubscriptionRequest_sbe_schema_version());
+
+    aeron_archive_client_stopRecordingSubscriptionRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_stopRecordingSubscriptionRequest_sbe_block_length(),
+        aeron_archive_client_stopRecordingSubscriptionRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_wrap_for_encode(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopRecordingSubscriptionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_stopRecordingSubscriptionRequest_sbe_block_length(),
+        aeron_archive_client_stopRecordingSubscriptionRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_wrap_for_decode(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopRecordingSubscriptionRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_sbe_rewind(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return aeron_archive_client_stopRecordingSubscriptionRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_encoded_length(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return aeron_archive_client_stopRecordingSubscriptionRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingSubscriptionRequest_buffer(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_stopRecordingSubscriptionRequest_mut_buffer(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_buffer_length(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_acting_version(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_controlSessionId(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_set_controlSessionId(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_correlationId(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_set_correlationId(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_meta_attribute(
+    const enum aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopRecordingSubscriptionRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_in_acting_version(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopRecordingSubscriptionRequest_subscriptionId(
+    const struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopRecordingSubscriptionRequest *aeron_archive_client_stopRecordingSubscriptionRequest_set_subscriptionId(
+    struct aeron_archive_client_stopRecordingSubscriptionRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopReplayRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopReplayRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STOPREPLAYREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STOPREPLAYREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_stopReplayRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_stopReplayRequest_meta_attribute
+{
+    aeron_archive_client_stopReplayRequest_meta_attribute_EPOCH,
+    aeron_archive_client_stopReplayRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_stopReplayRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_stopReplayRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_stopReplayRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_stopReplayRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_stopReplayRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_sbe_position(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplayRequest_set_sbe_position(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_stopReplayRequest_sbe_position_ptr(
+    struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_reset(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_stopReplayRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_copy(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    const struct aeron_archive_client_stopReplayRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplayRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_STOP_REPLAY_REQUEST_SBE_TEMPLATE_ID (uint16_t)7
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplayRequest_sbe_template_id(void)
+{
+    return (uint16_t)7;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplayRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplayRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_stopReplayRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplayRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_offset(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_wrap_and_apply_header(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_stopReplayRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_stopReplayRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_stopReplayRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_stopReplayRequest_sbe_schema_version());
+
+    aeron_archive_client_stopReplayRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_stopReplayRequest_sbe_block_length(),
+        aeron_archive_client_stopReplayRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_wrap_for_encode(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopReplayRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_stopReplayRequest_sbe_block_length(),
+        aeron_archive_client_stopReplayRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_wrap_for_decode(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopReplayRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_sbe_rewind(
+    struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return aeron_archive_client_stopReplayRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_encoded_length(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return aeron_archive_client_stopReplayRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplayRequest_buffer(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_stopReplayRequest_mut_buffer(
+    struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_buffer_length(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_acting_version(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplayRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_stopReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplayRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplayRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopReplayRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplayRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplayRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_controlSessionId(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_set_controlSessionId(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplayRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_stopReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplayRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplayRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopReplayRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplayRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplayRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_correlationId(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_set_correlationId(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplayRequest_replaySessionId_meta_attribute(
+    const enum aeron_archive_client_stopReplayRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopReplayRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopReplayRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplayRequest_replaySessionId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplayRequest_replaySessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplayRequest_replaySessionId_in_acting_version(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopReplayRequest_replaySessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplayRequest_replaySessionId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_replaySessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_replaySessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_replaySessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplayRequest_replaySessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplayRequest_replaySessionId(
+    const struct aeron_archive_client_stopReplayRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplayRequest *aeron_archive_client_stopReplayRequest_set_replaySessionId(
+    struct aeron_archive_client_stopReplayRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopReplicationRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/stopReplicationRequest.h
@@ -1,0 +1,638 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_STOPREPLICATIONREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_STOPREPLICATIONREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_stopReplicationRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_stopReplicationRequest_meta_attribute
+{
+    aeron_archive_client_stopReplicationRequest_meta_attribute_EPOCH,
+    aeron_archive_client_stopReplicationRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_stopReplicationRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_stopReplicationRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_stopReplicationRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_stopReplicationRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_stopReplicationRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_sbe_position(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplicationRequest_set_sbe_position(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_stopReplicationRequest_sbe_position_ptr(
+    struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_reset(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_stopReplicationRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_copy(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    const struct aeron_archive_client_stopReplicationRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplicationRequest_sbe_block_length(void)
+{
+    return (uint16_t)24;
+}
+
+#define AERON_ARCHIVE_CLIENT_STOP_REPLICATION_REQUEST_SBE_TEMPLATE_ID (uint16_t)51
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplicationRequest_sbe_template_id(void)
+{
+    return (uint16_t)51;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplicationRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplicationRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_stopReplicationRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplicationRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_offset(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_wrap_and_apply_header(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_stopReplicationRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_stopReplicationRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_stopReplicationRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_stopReplicationRequest_sbe_schema_version());
+
+    aeron_archive_client_stopReplicationRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_stopReplicationRequest_sbe_block_length(),
+        aeron_archive_client_stopReplicationRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_wrap_for_encode(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopReplicationRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_stopReplicationRequest_sbe_block_length(),
+        aeron_archive_client_stopReplicationRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_wrap_for_decode(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_stopReplicationRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_sbe_rewind(
+    struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return aeron_archive_client_stopReplicationRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_encoded_length(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return aeron_archive_client_stopReplicationRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplicationRequest_buffer(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_stopReplicationRequest_mut_buffer(
+    struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_buffer_length(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_acting_version(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplicationRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_stopReplicationRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplicationRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplicationRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopReplicationRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplicationRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplicationRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_controlSessionId(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_set_controlSessionId(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplicationRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_stopReplicationRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplicationRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplicationRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopReplicationRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplicationRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplicationRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_correlationId(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_set_correlationId(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_stopReplicationRequest_replicationId_meta_attribute(
+    const enum aeron_archive_client_stopReplicationRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_stopReplicationRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_stopReplicationRequest_replicationId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_stopReplicationRequest_replicationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_stopReplicationRequest_replicationId_in_acting_version(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_stopReplicationRequest_replicationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplicationRequest_replicationId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_replicationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_replicationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_replicationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_stopReplicationRequest_replicationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_stopReplicationRequest_replicationId(
+    const struct aeron_archive_client_stopReplicationRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_stopReplicationRequest *aeron_archive_client_stopReplicationRequest_set_replicationId(
+    struct aeron_archive_client_stopReplicationRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/taggedReplicateRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/taggedReplicateRequest.h
@@ -1,0 +1,1296 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_TAGGEDREPLICATEREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_TAGGEDREPLICATEREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_taggedReplicateRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_taggedReplicateRequest_meta_attribute
+{
+    aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH,
+    aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_taggedReplicateRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_taggedReplicateRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_taggedReplicateRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_sbe_position(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_set_sbe_position(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_taggedReplicateRequest_sbe_position_ptr(
+    struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_reset(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_copy(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const struct aeron_archive_client_taggedReplicateRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_sbe_block_length(void)
+{
+    return (uint16_t)52;
+}
+
+#define AERON_ARCHIVE_CLIENT_TAGGED_REPLICATE_REQUEST_SBE_TEMPLATE_ID (uint16_t)62
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_sbe_template_id(void)
+{
+    return (uint16_t)62;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_taggedReplicateRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_offset(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_wrap_and_apply_header(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_taggedReplicateRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_taggedReplicateRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_taggedReplicateRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_taggedReplicateRequest_sbe_schema_version());
+
+    aeron_archive_client_taggedReplicateRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_taggedReplicateRequest_sbe_block_length(),
+        aeron_archive_client_taggedReplicateRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_wrap_for_encode(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_taggedReplicateRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_taggedReplicateRequest_sbe_block_length(),
+        aeron_archive_client_taggedReplicateRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_wrap_for_decode(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_taggedReplicateRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_sbe_rewind(
+    struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return aeron_archive_client_taggedReplicateRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_encoded_length(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return aeron_archive_client_taggedReplicateRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_buffer(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_taggedReplicateRequest_mut_buffer(
+    struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_buffer_length(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_controlSessionId(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_set_controlSessionId(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_correlationId(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_set_correlationId(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_srcRecordingId_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_srcRecordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_srcRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_srcRecordingId_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_srcRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_srcRecordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_srcRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_srcRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_srcRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_srcRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_srcRecordingId(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_set_srcRecordingId(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_dstRecordingId_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_dstRecordingId_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_dstRecordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_dstRecordingId_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_dstRecordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_dstRecordingId_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_dstRecordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_dstRecordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_dstRecordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_dstRecordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_dstRecordingId(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_set_dstRecordingId(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_channelTagId_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_channelTagId_id(void)
+{
+    return 5;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_channelTagId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_channelTagId_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_channelTagId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_channelTagId_encoding_offset(void)
+{
+    return 32;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_channelTagId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_channelTagId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_channelTagId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_channelTagId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_channelTagId(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 32, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_set_channelTagId(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 32, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_subscriptionTagId_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId_id(void)
+{
+    return 6;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_subscriptionTagId_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_subscriptionTagId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId_encoding_offset(void)
+{
+    return 40;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_taggedReplicateRequest_subscriptionTagId(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 40, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_set_subscriptionTagId(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 40, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_srcControlStreamId_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId_id(void)
+{
+    return 7;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_srcControlStreamId_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_srcControlStreamId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId_encoding_offset(void)
+{
+    return 48;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId_null_value(void)
+{
+    return SBE_NULLVALUE_INT32;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId_min_value(void)
+{
+    return INT32_C(-2147483647);
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId_max_value(void)
+{
+    return INT32_C(2147483647);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF int32_t aeron_archive_client_taggedReplicateRequest_srcControlStreamId(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    int32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 48, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_set_srcControlStreamId(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const int32_t value)
+{
+    int32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 48, &val, sizeof(int32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_srcControlChannel_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_srcControlChannel_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_srcControlChannel_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_srcControlChannel_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_srcControlChannel_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_srcControlChannel_id(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_srcControlChannel_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_taggedReplicateRequest_srcControlChannel_length(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_srcControlChannel(
+    struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(
+        codec, aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_get_srcControlChannel(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest_string_view aeron_archive_client_taggedReplicateRequest_get_srcControlChannel_as_string_view(
+    struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_taggedReplicateRequest_srcControlChannel_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(
+        codec, aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_taggedReplicateRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_taggedReplicateRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_put_srcControlChannel(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_liveDestination_meta_attribute(
+    const enum aeron_archive_client_taggedReplicateRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_taggedReplicateRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_liveDestination_character_encoding(void)
+{
+    return "US-ASCII";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_liveDestination_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_taggedReplicateRequest_liveDestination_in_acting_version(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_taggedReplicateRequest_liveDestination_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_taggedReplicateRequest_liveDestination_id(void)
+{
+    return 9;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_liveDestination_header_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_taggedReplicateRequest_liveDestination_length(
+    const struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    uint32_t length;
+    memcpy(&length, codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec), sizeof(uint32_t));
+
+    return SBE_LITTLE_ENDIAN_ENCODE_32(length);
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_taggedReplicateRequest_liveDestination(
+    struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec), sizeof(uint32_t));
+    const char *field_ptr = (codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4);
+
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(
+        codec, aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4 + SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value)))
+    {
+        return NULL;
+    }
+
+    return field_ptr;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_taggedReplicateRequest_get_liveDestination(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    char *dst,
+    const uint64_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return 0;
+    }
+
+    uint32_t length_field_value;
+    memcpy(&length_field_value, codec->buffer + length_position, sizeof(uint32_t));
+    uint64_t data_length = SBE_LITTLE_ENDIAN_ENCODE_32(length_field_value);
+    uint64_t bytes_to_copy = length < data_length ? length : data_length;
+    uint64_t pos = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, pos + data_length))
+    {
+        return 0;
+    }
+
+    memcpy(dst, codec->buffer + pos, bytes_to_copy);
+
+    return bytes_to_copy;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest_string_view aeron_archive_client_taggedReplicateRequest_get_liveDestination_as_string_view(
+    struct aeron_archive_client_taggedReplicateRequest *const codec)
+{
+    uint32_t length_field_value = aeron_archive_client_taggedReplicateRequest_liveDestination_length(codec);
+    const char *field_ptr = codec->buffer + aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4;
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(
+        codec, aeron_archive_client_taggedReplicateRequest_sbe_position(codec) + 4 + length_field_value))
+    {
+        struct aeron_archive_client_taggedReplicateRequest_string_view ret = {NULL, 0};
+        return ret;
+    }
+
+    struct aeron_archive_client_taggedReplicateRequest_string_view ret = {field_ptr, length_field_value};
+
+    return ret;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_taggedReplicateRequest *aeron_archive_client_taggedReplicateRequest_put_liveDestination(
+    struct aeron_archive_client_taggedReplicateRequest *const codec,
+    const char *src,
+    const uint32_t length)
+{
+    uint64_t length_of_length_field = 4;
+    uint64_t length_position = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+    uint32_t length_field_value = SBE_LITTLE_ENDIAN_ENCODE_32(length);
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, length_position + length_of_length_field))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + length_position, &length_field_value, sizeof(uint32_t));
+    uint64_t pos = aeron_archive_client_taggedReplicateRequest_sbe_position(codec);
+
+    if (!aeron_archive_client_taggedReplicateRequest_set_sbe_position(codec, pos + length))
+    {
+        return NULL;
+    }
+
+    memcpy(codec->buffer + pos, src, length);
+
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/truncateRecordingRequest.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/truncateRecordingRequest.h
@@ -1,0 +1,731 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_TRUNCATERECORDINGREQUEST_H_
+#define _AERON_ARCHIVE_CLIENT_TRUNCATERECORDINGREQUEST_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "sourceLocation.h"
+#include "messageHeader.h"
+#include "booleanType.h"
+#include "recordingSignal.h"
+#include "controlResponseCode.h"
+#include "recordingState.h"
+#include "varAsciiEncoding.h"
+#include "varDataEncoding.h"
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_truncateRecordingRequest
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t position;
+    uint64_t acting_block_length;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_truncateRecordingRequest_meta_attribute
+{
+    aeron_archive_client_truncateRecordingRequest_meta_attribute_EPOCH,
+    aeron_archive_client_truncateRecordingRequest_meta_attribute_TIME_UNIT,
+    aeron_archive_client_truncateRecordingRequest_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_truncateRecordingRequest_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_truncateRecordingRequest_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_truncateRecordingRequest_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_truncateRecordingRequest_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_sbe_position(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return codec->position;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_truncateRecordingRequest_set_sbe_position(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    const uint64_t position)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT((position > codec->buffer_length), false))
+    {
+        errno = E100;
+        return false;
+    }
+    codec->position = position;
+
+    return true;
+}
+
+SBE_ONE_DEF uint64_t *aeron_archive_client_truncateRecordingRequest_sbe_position_ptr(
+    struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return &codec->position;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_reset(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version)
+{
+    codec->buffer = buffer;
+    codec->offset = offset;
+    codec->buffer_length = buffer_length;
+    codec->acting_block_length = acting_block_length;
+    codec->acting_version = acting_version;
+    if (!aeron_archive_client_truncateRecordingRequest_set_sbe_position(codec, offset + acting_block_length))
+    {
+        return NULL;
+    }
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_copy(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    const struct aeron_archive_client_truncateRecordingRequest *const other)
+{
+     codec->buffer = other->buffer;
+     codec->offset = other->offset;
+     codec->buffer_length = other->buffer_length;
+     codec->acting_block_length = other->acting_block_length;
+     codec->acting_version = other->acting_version;
+     codec->position = other->position;
+
+     return codec;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_sbe_block_length(void)
+{
+    return (uint16_t)32;
+}
+
+#define AERON_ARCHIVE_CLIENT_TRUNCATE_RECORDING_REQUEST_SBE_TEMPLATE_ID (uint16_t)13
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_sbe_template_id(void)
+{
+    return (uint16_t)13;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char* aeron_archive_client_truncateRecordingRequest_sbe_semantic_version(void)
+{
+    return "5.2";
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_truncateRecordingRequest_sbe_semantic_type(void)
+{
+    return "";
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_offset(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_wrap_and_apply_header(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    struct aeron_archive_client_messageHeader *const hdr)
+{
+    aeron_archive_client_messageHeader_wrap(
+        hdr, buffer + offset, 0, aeron_archive_client_messageHeader_sbe_schema_version(), buffer_length);
+
+    aeron_archive_client_messageHeader_set_blockLength(hdr, aeron_archive_client_truncateRecordingRequest_sbe_block_length());
+    aeron_archive_client_messageHeader_set_templateId(hdr, aeron_archive_client_truncateRecordingRequest_sbe_template_id());
+    aeron_archive_client_messageHeader_set_schemaId(hdr, aeron_archive_client_truncateRecordingRequest_sbe_schema_id());
+    aeron_archive_client_messageHeader_set_version(hdr, aeron_archive_client_truncateRecordingRequest_sbe_schema_version());
+
+    aeron_archive_client_truncateRecordingRequest_reset(
+        codec,
+        buffer + offset + aeron_archive_client_messageHeader_encoded_length(),
+        0,
+        buffer_length - aeron_archive_client_messageHeader_encoded_length(),
+        aeron_archive_client_truncateRecordingRequest_sbe_block_length(),
+        aeron_archive_client_truncateRecordingRequest_sbe_schema_version());
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_wrap_for_encode(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_truncateRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        aeron_archive_client_truncateRecordingRequest_sbe_block_length(),
+        aeron_archive_client_truncateRecordingRequest_sbe_schema_version());
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_wrap_for_decode(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_block_length,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_truncateRecordingRequest_reset(
+        codec,
+        buffer,
+        offset,
+        buffer_length,
+        acting_block_length,
+        acting_version);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_sbe_rewind(
+    struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return aeron_archive_client_truncateRecordingRequest_wrap_for_decode(
+        codec,
+        codec->buffer,
+        codec->offset,
+        codec->acting_block_length,
+        codec->acting_version,
+        codec->buffer_length);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_encoded_length(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return aeron_archive_client_truncateRecordingRequest_sbe_position(codec) - codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_truncateRecordingRequest_buffer(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_truncateRecordingRequest_mut_buffer(
+    struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_buffer_length(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_acting_version(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    return codec->acting_version;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_truncateRecordingRequest_controlSessionId_meta_attribute(
+    const enum aeron_archive_client_truncateRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_controlSessionId_id(void)
+{
+    return 1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_controlSessionId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_truncateRecordingRequest_controlSessionId_in_acting_version(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_truncateRecordingRequest_controlSessionId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_controlSessionId_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_controlSessionId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_controlSessionId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_controlSessionId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_controlSessionId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_controlSessionId(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_set_controlSessionId(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_truncateRecordingRequest_correlationId_meta_attribute(
+    const enum aeron_archive_client_truncateRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_correlationId_id(void)
+{
+    return 2;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_correlationId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_truncateRecordingRequest_correlationId_in_acting_version(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_truncateRecordingRequest_correlationId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_correlationId_encoding_offset(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_correlationId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_correlationId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_correlationId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_correlationId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_correlationId(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 8, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_set_correlationId(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 8, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_truncateRecordingRequest_recordingId_meta_attribute(
+    const enum aeron_archive_client_truncateRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_recordingId_id(void)
+{
+    return 3;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_recordingId_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_truncateRecordingRequest_recordingId_in_acting_version(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_truncateRecordingRequest_recordingId_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_recordingId_encoding_offset(void)
+{
+    return 16;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_recordingId_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_recordingId_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_recordingId_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_recordingId_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_recordingId(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 16, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_set_recordingId(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 16, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_truncateRecordingRequest_position_meta_attribute(
+    const enum aeron_archive_client_truncateRecordingRequest_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_truncateRecordingRequest_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_truncateRecordingRequest_position_id(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_truncateRecordingRequest_position_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_truncateRecordingRequest_position_in_acting_version(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_truncateRecordingRequest_position_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_position_encoding_offset(void)
+{
+    return 24;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_position_null_value(void)
+{
+    return SBE_NULLVALUE_INT64;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_position_min_value(void)
+{
+    return INT64_C(-9223372036854775807);
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_position_max_value(void)
+{
+    return INT64_C(9223372036854775807);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_truncateRecordingRequest_position_encoding_length(void)
+{
+    return 8;
+}
+
+SBE_ONE_DEF int64_t aeron_archive_client_truncateRecordingRequest_position(
+    const struct aeron_archive_client_truncateRecordingRequest *const codec)
+{
+    int64_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 24, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_64(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_truncateRecordingRequest *aeron_archive_client_truncateRecordingRequest_set_position(
+    struct aeron_archive_client_truncateRecordingRequest *const codec,
+    const int64_t value)
+{
+    int64_t val = SBE_LITTLE_ENDIAN_ENCODE_64(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 24, &val, sizeof(int64_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/varAsciiEncoding.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/varAsciiEncoding.h
@@ -1,0 +1,373 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_VARASCIIENCODING_H_
+#define _AERON_ARCHIVE_CLIENT_VARASCIIENCODING_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_varAsciiEncoding
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_varAsciiEncoding_meta_attribute
+{
+    aeron_archive_client_varAsciiEncoding_meta_attribute_EPOCH,
+    aeron_archive_client_varAsciiEncoding_meta_attribute_TIME_UNIT,
+    aeron_archive_client_varAsciiEncoding_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_varAsciiEncoding_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_varAsciiEncoding_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_varAsciiEncoding_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_varAsciiEncoding_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF struct aeron_archive_client_varAsciiEncoding *aeron_archive_client_varAsciiEncoding_reset(
+    struct aeron_archive_client_varAsciiEncoding *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_version)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT(((offset + -1) > buffer_length), false))
+    {
+        errno = E107;
+        return NULL;
+    }
+    codec->buffer = buffer;
+    codec->buffer_length = buffer_length;
+    codec->offset = offset;
+    codec->acting_version = acting_version;
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_varAsciiEncoding *aeron_archive_client_varAsciiEncoding_wrap(
+    struct aeron_archive_client_varAsciiEncoding *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_varAsciiEncoding_reset(codec, buffer, offset, buffer_length, acting_version);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varAsciiEncoding_encoded_length(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varAsciiEncoding_offset(
+    const struct aeron_archive_client_varAsciiEncoding *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_varAsciiEncoding_buffer(
+    const struct aeron_archive_client_varAsciiEncoding *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_varAsciiEncoding_mut_buffer(
+    struct aeron_archive_client_varAsciiEncoding *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varAsciiEncoding_buffer_length(
+    const struct aeron_archive_client_varAsciiEncoding *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varAsciiEncoding_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varAsciiEncoding_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_varAsciiEncoding_length_meta_attribute(
+    const enum aeron_archive_client_varAsciiEncoding_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varAsciiEncoding_length_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varAsciiEncoding_length_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_varAsciiEncoding_length_in_acting_version(
+    const struct aeron_archive_client_varAsciiEncoding *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_varAsciiEncoding_length_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varAsciiEncoding_length_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varAsciiEncoding_length_null_value(void)
+{
+    return SBE_NULLVALUE_UINT32;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varAsciiEncoding_length_min_value(void)
+{
+    return UINT32_C(0x0);
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varAsciiEncoding_length_max_value(void)
+{
+    return UINT32_C(0x40000000);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varAsciiEncoding_length_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varAsciiEncoding_length(
+    const struct aeron_archive_client_varAsciiEncoding *const codec)
+{
+    uint32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(uint32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_varAsciiEncoding *aeron_archive_client_varAsciiEncoding_set_length(
+    struct aeron_archive_client_varAsciiEncoding *const codec,
+    const uint32_t value)
+{
+    uint32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(uint32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_varAsciiEncoding_varData_meta_attribute(
+    const enum aeron_archive_client_varAsciiEncoding_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_varAsciiEncoding_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varAsciiEncoding_varData_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varAsciiEncoding_varData_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_varAsciiEncoding_varData_in_acting_version(
+    const struct aeron_archive_client_varAsciiEncoding *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_varAsciiEncoding_varData_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varAsciiEncoding_varData_encoding_offset(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint8_t aeron_archive_client_varAsciiEncoding_varData_null_value(void)
+{
+    return SBE_NULLVALUE_UINT8;
+}
+
+SBE_ONE_DEF uint8_t aeron_archive_client_varAsciiEncoding_varData_min_value(void)
+{
+    return (uint8_t)0;
+}
+
+SBE_ONE_DEF uint8_t aeron_archive_client_varAsciiEncoding_varData_max_value(void)
+{
+    return (uint8_t)254;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varAsciiEncoding_varData_encoding_length(void)
+{
+    return -1;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/varDataEncoding.h
+++ b/libaeron_archive_c_client-sys/generated/c/aeron_archive_client/varDataEncoding.h
@@ -1,0 +1,373 @@
+/* Generated SBE (Simple Binary Encoding) message codec */
+
+#ifndef _AERON_ARCHIVE_CLIENT_VARDATAENCODING_H_
+#define _AERON_ARCHIVE_CLIENT_VARDATAENCODING_H_
+
+#include <errno.h>
+#if !defined(__STDC_LIMIT_MACROS)
+#define __STDC_LIMIT_MACROS 1
+#endif
+#include <limits.h>
+#define SBE_FLOAT_NAN NAN
+#define SBE_DOUBLE_NAN NAN
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef __cplusplus
+#define SBE_ONE_DEF inline
+#else
+#define SBE_ONE_DEF static inline
+#endif
+
+/*
+ * Define some byte ordering macros
+ */
+#if defined(WIN32) || defined(_WIN32)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) _byteswap_ushort(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) _byteswap_ulong(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) _byteswap_uint64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) (v)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define SBE_LITTLE_ENDIAN_ENCODE_16(v) __builtin_bswap16(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_32(v) __builtin_bswap32(v)
+    #define SBE_LITTLE_ENDIAN_ENCODE_64(v) __builtin_bswap64(v)
+    #define SBE_BIG_ENDIAN_ENCODE_16(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_32(v) (v)
+    #define SBE_BIG_ENDIAN_ENCODE_64(v) (v)
+#else
+    #error "Byte Ordering of platform not determined. Set __BYTE_ORDER__ manually before including this file."
+#endif
+
+#if !defined(SBE_BOUNDS_CHECK_EXPECT)
+#  if defined(SBE_NO_BOUNDS_CHECK)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (false)
+#  elif defined(_MSC_VER)
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (exp)
+#  else 
+#    define SBE_BOUNDS_CHECK_EXPECT(exp, c) (__builtin_expect(exp, c))
+#  endif
+
+#endif
+
+#define SBE_NULLVALUE_INT8 INT8_MIN
+#define SBE_NULLVALUE_INT16 INT16_MIN
+#define SBE_NULLVALUE_INT32 INT32_MIN
+#define SBE_NULLVALUE_INT64 INT64_MIN
+#define SBE_NULLVALUE_UINT8 UINT8_MAX
+#define SBE_NULLVALUE_UINT16 UINT16_MAX
+#define SBE_NULLVALUE_UINT32 UINT32_MAX
+#define SBE_NULLVALUE_UINT64 UINT64_MAX
+
+#define E100 -50100 // E_BUF_SHORT
+#define E103 -50103 // VAL_UNKNOWN_ENUM
+#define E104 -50104 // I_OUT_RANGE_NUM
+#define E105 -50105 // I_OUT_RANGE_NUM
+#define E106 -50106 // I_OUT_RANGE_NUM
+#define E107 -50107 // BUF_SHORT_FLYWEIGHT
+#define E108 -50108 // BUF_SHORT_NXT_GRP_IND
+#define E109 -50109 // STR_TOO_LONG_FOR_LEN_TYP
+#define E110 -50110 // CNT_OUT_RANGE
+
+#ifndef SBE_STRERROR_DEFINED
+#define SBE_STRERROR_DEFINED
+SBE_ONE_DEF const char *sbe_strerror(const int errnum)
+{
+    switch (errnum)
+    {
+        case E100:
+            return "buffer too short";
+        case E103:
+            return "unknown value for enum";
+        case E104:
+            return "index out of range";
+        case E105:
+            return "index out of range";
+        case E106:
+            return "length too large";
+        case E107:
+            return "buffer too short for flyweight";
+        case E108:
+            return "buffer too short to support next group index";
+        case E109:
+            return "std::string too long for length type";
+        case E110:
+            return "count outside of allowed range";
+        default:
+            return "unknown error";
+    }
+}
+#endif
+
+struct aeron_archive_client_varDataEncoding
+{
+    char *buffer;
+    uint64_t buffer_length;
+    uint64_t offset;
+    uint64_t acting_version;
+};
+
+enum aeron_archive_client_varDataEncoding_meta_attribute
+{
+    aeron_archive_client_varDataEncoding_meta_attribute_EPOCH,
+    aeron_archive_client_varDataEncoding_meta_attribute_TIME_UNIT,
+    aeron_archive_client_varDataEncoding_meta_attribute_SEMANTIC_TYPE,
+    aeron_archive_client_varDataEncoding_meta_attribute_PRESENCE
+};
+
+union aeron_archive_client_varDataEncoding_float_as_uint
+{
+    float fp_value;
+    uint32_t uint_value;
+};
+
+union aeron_archive_client_varDataEncoding_double_as_uint
+{
+    double fp_value;
+    uint64_t uint_value;
+};
+
+struct aeron_archive_client_varDataEncoding_string_view
+{
+    const char* data;
+    size_t length;
+};
+
+SBE_ONE_DEF struct aeron_archive_client_varDataEncoding *aeron_archive_client_varDataEncoding_reset(
+    struct aeron_archive_client_varDataEncoding *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t buffer_length,
+    const uint64_t acting_version)
+{
+    if (SBE_BOUNDS_CHECK_EXPECT(((offset + -1) > buffer_length), false))
+    {
+        errno = E107;
+        return NULL;
+    }
+    codec->buffer = buffer;
+    codec->buffer_length = buffer_length;
+    codec->offset = offset;
+    codec->acting_version = acting_version;
+
+    return codec;
+}
+
+SBE_ONE_DEF struct aeron_archive_client_varDataEncoding *aeron_archive_client_varDataEncoding_wrap(
+    struct aeron_archive_client_varDataEncoding *const codec,
+    char *buffer,
+    const uint64_t offset,
+    const uint64_t acting_version,
+    const uint64_t buffer_length)
+{
+    return aeron_archive_client_varDataEncoding_reset(codec, buffer, offset, buffer_length, acting_version);
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varDataEncoding_encoded_length(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varDataEncoding_offset(
+    const struct aeron_archive_client_varDataEncoding *const codec)
+{
+    return codec->offset;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_varDataEncoding_buffer(
+    const struct aeron_archive_client_varDataEncoding *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF char *aeron_archive_client_varDataEncoding_mut_buffer(
+    struct aeron_archive_client_varDataEncoding *const codec)
+{
+    return codec->buffer;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varDataEncoding_buffer_length(
+    const struct aeron_archive_client_varDataEncoding *const codec)
+{
+    return codec->buffer_length;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varDataEncoding_sbe_schema_id(void)
+{
+    return (uint16_t)101;
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varDataEncoding_sbe_schema_version(void)
+{
+    return (uint16_t)10;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_varDataEncoding_length_meta_attribute(
+    const enum aeron_archive_client_varDataEncoding_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_varDataEncoding_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_varDataEncoding_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_varDataEncoding_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_varDataEncoding_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varDataEncoding_length_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varDataEncoding_length_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_varDataEncoding_length_in_acting_version(
+    const struct aeron_archive_client_varDataEncoding *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_varDataEncoding_length_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varDataEncoding_length_encoding_offset(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varDataEncoding_length_null_value(void)
+{
+    return SBE_NULLVALUE_UINT32;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varDataEncoding_length_min_value(void)
+{
+    return UINT32_C(0x0);
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varDataEncoding_length_max_value(void)
+{
+    return UINT32_C(0x40000000);
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varDataEncoding_length_encoding_length(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint32_t aeron_archive_client_varDataEncoding_length(
+    const struct aeron_archive_client_varDataEncoding *const codec)
+{
+    uint32_t val;
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(&val, codec->buffer + codec->offset + 0, sizeof(uint32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return SBE_LITTLE_ENDIAN_ENCODE_32(val);
+}
+
+SBE_ONE_DEF struct aeron_archive_client_varDataEncoding *aeron_archive_client_varDataEncoding_set_length(
+    struct aeron_archive_client_varDataEncoding *const codec,
+    const uint32_t value)
+{
+    uint32_t val = SBE_LITTLE_ENDIAN_ENCODE_32(value);
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    memcpy(codec->buffer + codec->offset + 0, &val, sizeof(uint32_t));
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    return codec;
+}
+
+SBE_ONE_DEF const char *aeron_archive_client_varDataEncoding_varData_meta_attribute(
+    const enum aeron_archive_client_varDataEncoding_meta_attribute attribute)
+{
+    switch (attribute)
+    {
+        case aeron_archive_client_varDataEncoding_meta_attribute_EPOCH: return "";
+        case aeron_archive_client_varDataEncoding_meta_attribute_TIME_UNIT: return "";
+        case aeron_archive_client_varDataEncoding_meta_attribute_SEMANTIC_TYPE: return "";
+        case aeron_archive_client_varDataEncoding_meta_attribute_PRESENCE: return "required";
+    }
+
+    return "";
+}
+
+SBE_ONE_DEF uint16_t aeron_archive_client_varDataEncoding_varData_id(void)
+{
+    return -1;
+}
+
+SBE_ONE_DEF uint64_t aeron_archive_client_varDataEncoding_varData_since_version(void)
+{
+    return 0;
+}
+
+SBE_ONE_DEF bool aeron_archive_client_varDataEncoding_varData_in_acting_version(
+    const struct aeron_archive_client_varDataEncoding *const codec)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
+    return codec->acting_version >= aeron_archive_client_varDataEncoding_varData_since_version();
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varDataEncoding_varData_encoding_offset(void)
+{
+    return 4;
+}
+
+SBE_ONE_DEF uint8_t aeron_archive_client_varDataEncoding_varData_null_value(void)
+{
+    return SBE_NULLVALUE_UINT8;
+}
+
+SBE_ONE_DEF uint8_t aeron_archive_client_varDataEncoding_varData_min_value(void)
+{
+    return (uint8_t)0;
+}
+
+SBE_ONE_DEF uint8_t aeron_archive_client_varDataEncoding_varData_max_value(void)
+{
+    return (uint8_t)254;
+}
+
+SBE_ONE_DEF size_t aeron_archive_client_varDataEncoding_varData_encoding_length(void)
+{
+    return -1;
+}
+
+#endif

--- a/libaeron_archive_c_client-sys/src/lib.rs
+++ b/libaeron_archive_c_client-sys/src/lib.rs
@@ -1,0 +1,40 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(clippy::all)]
+
+use libaeron_sys::*;
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(test)]
+mod tests {
+    use std::ptr::null_mut;
+
+    #[test]
+    fn interop_check() {
+        // ensure we can call functions from both libs and the types are interoperable
+        let mut archive_ctx = null_mut();
+        let rc = unsafe { crate::aeron_archive_context_init(&mut archive_ctx) };
+        assert_eq!(rc, 0);
+
+        let mut aeron_ctx = null_mut();
+        let rc = unsafe { libaeron_sys::aeron_context_init(&mut aeron_ctx) };
+        assert_eq!(rc, 0);
+
+        let aeron: *mut libaeron_sys::aeron_t = null_mut();
+        let rc = unsafe { crate::aeron_archive_context_set_aeron(archive_ctx, aeron) };
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn version_check() {
+        let major = unsafe { libaeron_sys::aeron_version_major() };
+        let minor = unsafe { libaeron_sys::aeron_version_minor() };
+        let patch = unsafe { libaeron_sys::aeron_version_patch() };
+
+        let aeron_version = format!("{}.{}.{}", major, minor, patch);
+        let cargo_version = env!("CARGO_PKG_VERSION");
+        assert_eq!(aeron_version, cargo_version);
+    }
+}

--- a/libaeron_driver-sys/Cargo.toml
+++ b/libaeron_driver-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaeron_driver-sys"
-version = "1.47.0"
+version = "1.47.1"
 authors = ["Bradlee Speice <bradlee@speice.io>"]
 repository = "https://github.com/bspeice/libaeron-sys"
 documentation = "https://docs.rs/libaeron_driver-sys"

--- a/libaeron_driver-sys/README.md
+++ b/libaeron_driver-sys/README.md
@@ -1,6 +1,6 @@
 # libaeron-sys
 
-[![github-ci](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml/badge.svg)](https://github.com/amoskvin/libaeron-sys/actions/workflows/ci.yml)
+[![github-ci](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml/badge.svg)](https://github.com/bspeice/libaeron-sys/actions/workflows/ci.yml)
 [![docs.rs](https://docs.rs/libaeron_driver-sys/badge.svg)](https://docs.rs/libaeron_driver-sys/)
 
-Rust bindings for the [Aeron](https://github.com/real-logic/aeron) C [Media Driver](https://github.com/real-logic/aeron/tree/master/aeron-driver).
+Rust bindings for the [Aeron](https://github.com/aeron-io/aeron) C [Media Driver](https://github.com/aeron-io/aeron/tree/master/aeron-driver).

--- a/update-version.sh
+++ b/update-version.sh
@@ -15,7 +15,7 @@ update_codecs() {
     crate=$1
     echo "Generating codecs..."
     codec_dir="${crate}/generated/c"
-    git rm -rfq "${codec_dir}"
+    git rm -rfq --ignore-unmatch "${codec_dir}"
     (
         cd "${crate}/aeron" && \
             ./gradlew -Dcodec.target.dir="${codec_dir}" \
@@ -25,7 +25,7 @@ update_codecs() {
 }
 
 echo "Updating submodules..."
-git submodule update --init
+git submodule update --init --remote
 git submodule foreach git checkout "${version}"
 
 for crate in "${basedir}"/libaeron*-sys; do

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Script to bump the version
+# ./update-version.sh 1.47.0
+
+set -eu
+
+version="${1:?Usage: $0 <version>}"
+
+script="$( readlink -f $0 )"
+basedir="${script%/*}"
+cd "${basedir}"
+
+update_codecs() {
+    crate=$1
+    echo "Generating codecs..."
+    codec_dir="${crate}/generated/c"
+    git rm -rfq "${codec_dir}"
+    (
+        cd "${crate}/aeron" && \
+            ./gradlew -Dcodec.target.dir="${codec_dir}" \
+                :aeron-archive:generateCCodecs --no-daemon
+    )
+    git add "${codec_dir}"
+}
+
+echo "Updating submodules..."
+git submodule update --init
+git submodule foreach git checkout "${version}"
+
+for crate in "${basedir}"/libaeron*-sys; do
+    echo "Updating version for ${crate##*/}..."
+    sed -i \
+        -e "s#^version = \"[0-9.]*\"\$#version = \"${version}\"#" \
+        -e "s#\(^libaeron.*version = \)\"=[0-9.]*\"#\\1\"=${version}\"#" \
+        "${crate}/Cargo.toml"
+
+    git add "${crate}/aeron" "${crate}/Cargo.toml"
+
+    if [[ "libaeron_archive_c_client-sys" == "${crate##*/}" ]]; then
+        update_codecs "${crate}"
+    fi
+done
+
+echo "Testing..."
+cargo clean -v
+cargo test --quiet
+
+git status
+
+echo "If everything looks OK, run: git commit -m 'Upgrade to Aeron ${version}'"


### PR DESCRIPTION
Aeron 1.47.0 now provides a C library Aeron Archive API, so I added an additional crate for it.

It's a but cumbersome since building it requires generating SBE codecs, which is done by CMake running Gradle and building the  Java portion... which is problematic if your CI doesn't have direct internet access since Gradle needs to download lots of dependencies.

I worked around this by checking in the SBE codecs and adding a wrapper `CMakeLists.txt` that makes it possible to build the crate without Gradle or Java. I also added `update-version.sh` to make it simpler to bump versions and regenerate the codecs.